### PR TITLE
feat: select services by service-proxy-name label

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,35 @@ The last option is the simplest and most flexible, but it has a limitation: Kube
 but only traffic on specific ports (see: [Kubernetes Issue #23864](https://github.com/kubernetes/kubernetes/issues/23864)).
 Additionally, kube-proxy does not perform SNAT, which causes outgoing traffic from the pod to use the default gateway of the host where it is running.
 
-To address these issues, we have added an additional controller that performs 1:1 NAT for services annotated with `networking.cozystack.io/wholeIP`.
+To address these issues, we have added an additional controller that performs 1:1 NAT for services selected by either the `service.kubernetes.io/service-proxy-name: cozy-proxy` label or the `networking.cozystack.io/wholeIP` annotation.
 
 ## How It Works
 
-cozy-proxy is a simple Kubernetes controller that watches for services with the `networking.cozystack.io/wholeIP` annotation. When it finds such a service, it creates an NFT rule that forwards traffic from the service's external IP to the pod's IP and vice versa, performing source-IP preservation for egress traffic.
+cozy-proxy is a simple Kubernetes controller that watches for services selected by either of the following:
+
+- **`service.kubernetes.io/service-proxy-name: cozy-proxy`** label (recommended) — the standard Kubernetes mechanism for delegating a service to a non-default proxy. kube-proxy skips services carrying this label, so cozy-proxy becomes the sole handler and no rules collide.
+- **`networking.cozystack.io/wholeIP`** annotation — also selects the service for management. The annotation value additionally drives the ingress mode (see below).
+
+When it finds such a service, it creates NFT rules that forward traffic from the service's external IP to the pod's IP and vice versa, performing source-IP preservation for egress traffic.
 
 This controller can be used together with kube-proxy and Cilium in kube-proxy replacement mode.
 
-## Service annotations
+### Which selector should I use?
 
-cozy-proxy reacts to Services that carry the `networking.cozystack.io/wholeIP`
-annotation. The annotation value selects the ingress mode:
+- If your cluster runs **plain kube-proxy** (iptables or IPVS mode) — for example, a default RKE2/kubeadm install with Calico or Flannel — use the `service.kubernetes.io/service-proxy-name: cozy-proxy` label. Without it, kube-proxy installs its own LoadBalancer rules that conflict with cozy-proxy's NAT and break outbound SNAT.
+- If your cluster runs **Cilium in kube-proxy replacement mode** (as in the reference Cozystack environment), either selector works.
+
+You can safely set both on the same service.
+
+## Ingress mode
+
+The `networking.cozystack.io/wholeIP` annotation value selects the ingress mode:
 
 | Value     | Behavior                                                                                                        |
 |-----------|-----------------------------------------------------------------------------------------------------------------|
 | `"true"`  | **Whole-IP passthrough.** All TCP/UDP traffic to the LoadBalancer IP is forwarded to the backend pod.           |
 | `"false"` | **Per-port filtering.** Only TCP/UDP traffic to ports listed in `Service.spec.ports` is forwarded; rest dropped.|
-| absent    | Service is not managed by cozy-proxy.                                                                           |
+| absent    | Defaults to **passthrough** (services selected by label only behave the same as `wholeIP: "true"`).             |
 
 In both managed modes, egress traffic from the backend pod is SNATed to the
 LoadBalancer IP for source-IP preservation.
@@ -77,15 +88,17 @@ helm install cozy-proxy charts/cozy-proxy -n kube-system
 
 ## Usage
 
-Create a LoadBalancer service with `networking.cozystack.io/wholeIP: "true"` annotation:
+Create a LoadBalancer service with the `service.kubernetes.io/service-proxy-name: cozy-proxy` label. This also tells kube-proxy to stay away from the service. The `networking.cozystack.io/wholeIP: "true"` annotation is shown for clarity but is optional when the label is present:
 
 ```yaml
 apiVersion: v1
 kind: Service
 metadata:
+  name: example-service
+  labels:
+    service.kubernetes.io/service-proxy-name: cozy-proxy
   annotations:
     networking.cozystack.io/wholeIP: "true"
-  name: example-service
 spec:
   allocateLoadBalancerNodePorts: false
   externalTrafficPolicy: Local

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ helm install cozy-proxy charts/cozy-proxy -n kube-system
 
 ## Usage
 
-Create a LoadBalancer service with the `service.kubernetes.io/service-proxy-name: cozy-proxy` label. This also tells kube-proxy to stay away from the service. The `networking.cozystack.io/wholeIP: "true"` annotation is shown for clarity but is optional when the label is present:
+Create a LoadBalancer service with the `service.kubernetes.io/service-proxy-name: cozy-proxy` label. This also tells kube-proxy to stay away from the service:
 
 ```yaml
 apiVersion: v1
@@ -97,8 +97,6 @@ metadata:
   name: example-service
   labels:
     service.kubernetes.io/service-proxy-name: cozy-proxy
-  annotations:
-    networking.cozystack.io/wholeIP: "true"
 spec:
   allocateLoadBalancerNodePorts: false
   externalTrafficPolicy: Local

--- a/pkg/controllers/services_controller.go
+++ b/pkg/controllers/services_controller.go
@@ -210,7 +210,7 @@ func (c *ServicesController) addServiceFunc(obj interface{}) {
 		// Object is not a Service.
 		return
 	}
-	if !hasWholeIPAnnotation(svc) {
+	if !isCozyProxyService(svc) {
 		return
 	}
 
@@ -272,8 +272,8 @@ func (c *ServicesController) updateServiceFunc(oldObj, newObj interface{}) {
 		return
 	}
 
-	// If the required annotation is missing, remove the service mapping and delete NAT rules if applicable.
-	if !hasWholeIPAnnotation(svc) {
+	// If the service no longer matches our selection criteria, remove the service mapping and delete NAT rules if applicable.
+	if !isCozyProxyService(svc) {
 		if se, exists := c.Services.Get(svc.Namespace, svc.Name); exists {
 			if hasValidServiceIP(se.Service) && hasValidEndpointIP(se.Endpoint) {
 				svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
@@ -465,11 +465,35 @@ func hasValidEndpointIP(ep *v1.Endpoints) bool {
 const (
 	wholeIPAnnotation   = "networking.cozystack.io/wholeIP"
 	allowICMPAnnotation = "networking.cozystack.io/allowICMP"
+
+	// serviceProxyNameLabel is the standard Kubernetes label used to delegate
+	// a service to a non-default proxy implementation; kube-proxy skips
+	// services carrying it.
+	serviceProxyNameLabel = "service.kubernetes.io/service-proxy-name"
+
+	// serviceProxyName is the value cozy-proxy matches in serviceProxyNameLabel.
+	serviceProxyName = "cozy-proxy"
 )
 
-// hasWholeIPAnnotation reports whether the service is opted into cozy-proxy
-// management via the wholeIP annotation. Any value triggers management — the
-// value's meaning (passthrough vs port-filter) is determined by wholeIPPassthrough.
+// isCozyProxyService reports whether the service should be managed by cozy-proxy.
+// A service is selected if it carries the
+// service.kubernetes.io/service-proxy-name=cozy-proxy label (standard
+// Kubernetes mechanism, also tells kube-proxy to ignore the service) or the
+// networking.cozystack.io/wholeIP annotation (any value — the value drives
+// passthrough vs port-filter mode, see wholeIPPassthrough).
+func isCozyProxyService(svc *v1.Service) bool {
+	if svc == nil {
+		return false
+	}
+	if svc.Labels[serviceProxyNameLabel] == serviceProxyName {
+		return true
+	}
+	return hasWholeIPAnnotation(svc)
+}
+
+// hasWholeIPAnnotation reports whether the service carries the wholeIP
+// annotation. Any value is accepted; the value's meaning (passthrough vs
+// port-filter) is determined by wholeIPPassthrough.
 func hasWholeIPAnnotation(svc *v1.Service) bool {
 	if svc == nil {
 		return false
@@ -479,9 +503,9 @@ func hasWholeIPAnnotation(svc *v1.Service) bool {
 }
 
 // wholeIPPassthrough reports whether ingress traffic should bypass port
-// filtering. Defaults to true (current behavior) for any value other than
-// the explicit string "false", preserving backward compatibility for services
-// rendered by older charts (annotation: "true") and services with no value.
+// filtering. Defaults to true for any value other than the explicit string
+// "false", so services selected by label alone (no annotation) and services
+// with annotation: "true" both behave as passthrough.
 func wholeIPPassthrough(svc *v1.Service) bool {
 	if svc == nil || svc.Annotations == nil {
 		return true


### PR DESCRIPTION
## Summary

Adds support for selecting services via the standard Kubernetes `service.kubernetes.io/service-proxy-name: cozy-proxy` label, in addition to the existing `networking.cozystack.io/wholeIP: "true"` annotation. A service matching either selector is managed by cozy-proxy.

## Motivation

Since v0.2.0 cozy-proxy performs stateless NAT in the `raw` table (`early_snat` chain). On clusters running plain kube-proxy (iptables/IPVS) — e.g. default RKE2 + Calico + MetalLB — kube-proxy installs its own LoadBalancer rules that race with cozy-proxy's raw-table NAT and break outbound SNAT. The `service.kubernetes.io/service-proxy-name` label is the standard Kubernetes mechanism that instructs kube-proxy to ignore a service, letting cozy-proxy fully own its packet path. Cozystack itself adopted the same label on VM LoadBalancer services in cozystack/cozystack#2357.

The legacy annotation is kept as-is so existing deployments need no changes.

## Changes

- Controller now matches a service if it carries either selector
- README documents both selectors and guides users on which to pick

## Test plan

- [ ] Plain kube-proxy cluster (RKE2 + Calico + MetalLB BGP): verify outbound SNAT works for services labeled `service-proxy-name=cozy-proxy`
- [ ] Cozystack reference env (Cilium KPR): verify existing annotation-only services continue to work unchanged
- [ ] Service with both selectors set: managed exactly once
- [ ] Removing the last selector from a managed service: rules cleaned up

Refs: https://github.com/cozystack/cozy-proxy/issues/8