### PR TITLE
fix: disable probe and metrics endpoints by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,8 +34,8 @@ func init() {
 func main() {
 	var probeAddr string
 	var metricsAddr string
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":0", "The address the probe endpoint binds to.")
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":0", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", "0", "The address the probe endpoint binds to. Set to \"0\" to disable.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to. Set to \"0\" to disable.")
 	opts := zap.Options{
 		Development: true,
 	}


### PR DESCRIPTION
## Summary

Change the defaults for `--health-probe-bind-address` and `--metrics-bind-address` from `":0"` (bind to a random free port) to `"0"` (disabled), which is the controller-runtime convention for turning off the server.

## Why

`netstat` on a node running cozy-proxy showed two unexpected high-port listeners:

```
tcp6  0  0 :::40267  :::*  LISTEN  109979/cozy-proxy
tcp6  0  0 :::33869  :::*  LISTEN  109979/cozy-proxy
```

Because the chart runs cozy-proxy with `hostNetwork: true`, those ports were exposed directly on the host. Users who want health probes or metrics can still opt in by passing an explicit bind address via flag.

Verified against controller-runtime v0.20.1:
- Metrics (`pkg/metrics/server/server.go`): `BindAddress == "0"` skips server creation entirely.
- Probe (`pkg/manager/manager.go`): `addr == "" || addr == "0"` returns a nil listener, so no probe server is started.
- The previous `":0"` value instead fell through to `net.Listen("tcp", ":0")`, which is exactly what produced the random high ports.

## Test plan

- [ ] Build and deploy; verify `netstat -ltnp` on the node shows no cozy-proxy listeners
- [ ] Pass `--health-probe-bind-address=:8081` and confirm the probe endpoint comes up on that port
- [ ] Pass `--metrics-bind-address=:8080` and confirm metrics are served

Fixes #5