### PR TITLE
feat: per-service ingress port filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,45 @@ The last option is the simplest and most flexible, but it has a limitation: Kube
 but only traffic on specific ports (see: [Kubernetes Issue #23864](https://github.com/kubernetes/kubernetes/issues/23864)).
 Additionally, kube-proxy does not perform SNAT, which causes outgoing traffic from the pod to use the default gateway of the host where it is running.
 
-To address these issues, we have added an additional controller that performs 1:1 NAT for services annotated with `networking.cozystack.io/wholeIP=true`.
+To address these issues, we have added an additional controller that performs 1:1 NAT for services annotated with `networking.cozystack.io/wholeIP`.
 
 ## How It Works
 
-cozy-proxy is a simple Kubernetes controller that watches for services with the `networking.cozystack.io/wholeIP=true` annotation. When it finds such a service, it creates an NFT rule that forwards all traffic from the service's external IP to the pod's IP and vice versa. It also disables connection tracking (conntrack) for traffic between the service and the pod, offloading that work to NFTables.
+cozy-proxy is a simple Kubernetes controller that watches for services with the `networking.cozystack.io/wholeIP` annotation. When it finds such a service, it creates an NFT rule that forwards traffic from the service's external IP to the pod's IP and vice versa, performing source-IP preservation for egress traffic.
 
 This controller can be used together with kube-proxy and Cilium in kube-proxy replacement mode.
+
+## Service annotations
+
+cozy-proxy reacts to Services that carry the `networking.cozystack.io/wholeIP`
+annotation. The annotation value selects the ingress mode:
+
+| Value     | Behavior                                                                                                        |
+|-----------|-----------------------------------------------------------------------------------------------------------------|
+| `"true"`  | **Whole-IP passthrough.** All TCP/UDP traffic to the LoadBalancer IP is forwarded to the backend pod.           |
+| `"false"` | **Per-port filtering.** Only TCP/UDP traffic to ports listed in `Service.spec.ports` is forwarded; rest dropped.|
+| absent    | Service is not managed by cozy-proxy.                                                                           |
+
+In both managed modes, egress traffic from the backend pod is SNATed to the
+LoadBalancer IP for source-IP preservation.
+
+## Datapath
+
+The nftables ruleset placed in table `ip cozy_proxy` consists of:
+
+- Chain `egress_snat` at priority `raw` (-300): rewrites packet source IP via
+  the `pod_svc` map for outbound traffic from managed pods. Runs before
+  conntrack so the recorded tuple has `saddr=LB_IP`.
+- Chain `ingress_dnat` at priority `mangle` (-150): rewrites packet
+  destination IP via the `svc_pod` map for inbound traffic to a LoadBalancer
+  IP. Runs after conntrack so reply packets of egress flows are matched
+  correctly.
+- Chain `port_filter` at priority `filter` (0): for Services in port-filter
+  mode (`wholeIP: "false"`), drops ingress packets whose
+  `(daddr, l4proto, dport)` is not in `allowed_ports`. The chain accepts
+  packets in conntrack states `established` or `related` first, so reply
+  packets of egress flows bypass the filter even when their dport is the VM's
+  ephemeral source port.
 
 ## Installation
 
@@ -35,7 +67,7 @@ helm install cozy-proxy charts/cozy-proxy -n kube-system
 
 ## Usage
 
-Create a LoadBalancer service with `networking.cozystack.io/wholeIP=true` annotation:
+Create a LoadBalancer service with `networking.cozystack.io/wholeIP: "true"` annotation:
 
 ```yaml
 apiVersion: v1

--- a/pkg/controllers/services_controller.go
+++ b/pkg/controllers/services_controller.go
@@ -231,8 +231,19 @@ func (c *ServicesController) addServiceFunc(obj interface{}) {
 	if err == nil && ep != nil && hasValidEndpointIP(ep) && hasValidServiceIP(svc) {
 		se.Endpoint = ep
 		c.Services.Set(svc.Namespace, svc.Name, se)
+		svcIP := svc.Status.LoadBalancer.Ingress[0].IP
 		// Ensure NAT mapping rules are set.
-		c.Proxy.EnsureRules(svc.Status.LoadBalancer.Ingress[0].IP, ep.Subsets[0].Addresses[0].IP)
+		c.Proxy.EnsureRules(svcIP, ep.Subsets[0].Addresses[0].IP)
+		// Apply (or remove) port filtering depending on annotation value.
+		if wholeIPPassthrough(svc) {
+			if err := c.Proxy.DeletePortFilter(svcIP); err != nil {
+				log.Error(err, "failed to delete port filter", "svcIP", svcIP)
+			}
+		} else {
+			if err := c.Proxy.EnsurePortFilter(svcIP, svc.Spec.Ports); err != nil {
+				log.Error(err, "failed to ensure port filter", "svcIP", svcIP)
+			}
+		}
 	}
 }
 
@@ -253,6 +264,9 @@ func (c *ServicesController) deleteServiceFunc(obj interface{}) {
 		return
 	}
 
+	if err := c.Proxy.DeletePortFilter(se.Service.Status.LoadBalancer.Ingress[0].IP); err != nil {
+		log.Error(err, "failed to delete port filter on svc deletion", "svcIP", se.Service.Status.LoadBalancer.Ingress[0].IP)
+	}
 	c.Proxy.DeleteRules(se.Service.Status.LoadBalancer.Ingress[0].IP, se.Endpoint.Subsets[0].Addresses[0].IP)
 	c.Services.Delete(svc.Namespace, svc.Name)
 }
@@ -270,6 +284,9 @@ func (c *ServicesController) updateServiceFunc(oldObj, newObj interface{}) {
 	if !hasWholeIPAnnotation(svc) {
 		if se, exists := c.Services.Get(svc.Namespace, svc.Name); exists {
 			if hasValidServiceIP(se.Service) && hasValidEndpointIP(se.Endpoint) {
+				if err := c.Proxy.DeletePortFilter(se.Service.Status.LoadBalancer.Ingress[0].IP); err != nil {
+					log.Error(err, "failed to delete port filter", "svcIP", se.Service.Status.LoadBalancer.Ingress[0].IP)
+				}
 				c.Proxy.DeleteRules(
 					se.Service.Status.LoadBalancer.Ingress[0].IP,
 					se.Endpoint.Subsets[0].Addresses[0].IP,
@@ -284,6 +301,9 @@ func (c *ServicesController) updateServiceFunc(oldObj, newObj interface{}) {
 	if !hasValidServiceIP(svc) {
 		if se, exists := c.Services.Get(svc.Namespace, svc.Name); exists {
 			if hasValidServiceIP(se.Service) && hasValidEndpointIP(se.Endpoint) {
+				if err := c.Proxy.DeletePortFilter(se.Service.Status.LoadBalancer.Ingress[0].IP); err != nil {
+					log.Error(err, "failed to delete port filter", "svcIP", se.Service.Status.LoadBalancer.Ingress[0].IP)
+				}
 				c.Proxy.DeleteRules(
 					se.Service.Status.LoadBalancer.Ingress[0].IP,
 					se.Endpoint.Subsets[0].Addresses[0].IP,
@@ -324,10 +344,17 @@ func (c *ServicesController) updateServiceFunc(oldObj, newObj interface{}) {
 
 	// At this point, both the Service and Endpoint have valid IPs.
 	// Ensure NAT mapping is up-to-date.
-	c.Proxy.EnsureRules(
-		svc.Status.LoadBalancer.Ingress[0].IP,
-		ep.Subsets[0].Addresses[0].IP,
-	)
+	svcIP := svc.Status.LoadBalancer.Ingress[0].IP
+	c.Proxy.EnsureRules(svcIP, ep.Subsets[0].Addresses[0].IP)
+	if wholeIPPassthrough(svc) {
+		if err := c.Proxy.DeletePortFilter(svcIP); err != nil {
+			log.Error(err, "failed to delete port filter", "svcIP", svcIP)
+		}
+	} else {
+		if err := c.Proxy.EnsurePortFilter(svcIP, svc.Spec.Ports); err != nil {
+			log.Error(err, "failed to ensure port filter", "svcIP", svcIP)
+		}
+	}
 
 	// Update or add the service mapping with the new endpoint.
 	c.Services.Set(svc.Namespace, svc.Name, &ServiceEndpoints{Service: svc, Endpoint: ep})
@@ -447,10 +474,28 @@ func hasValidEndpointIP(ep *v1.Endpoints) bool {
 	return ep.Subsets[0].Addresses[0].IP != ""
 }
 
-// hasWholeIPAnnotation checks if the service has the wholeIP annotation set to true.
+const wholeIPAnnotation = "networking.cozystack.io/wholeIP"
+
+// hasWholeIPAnnotation reports whether the service is opted into cozy-proxy
+// management via the wholeIP annotation. Any value triggers management — the
+// value's meaning (passthrough vs port-filter) is determined by wholeIPPassthrough.
 func hasWholeIPAnnotation(svc *v1.Service) bool {
-	val, ok := svc.Annotations["networking.cozystack.io/wholeIP"]
-	return ok && val == "true"
+	if svc == nil {
+		return false
+	}
+	_, ok := svc.Annotations[wholeIPAnnotation]
+	return ok
+}
+
+// wholeIPPassthrough reports whether ingress traffic should bypass port
+// filtering. Defaults to true (current behavior) for any value other than
+// the explicit string "false", preserving backward compatibility for services
+// rendered by older charts (annotation: "true") and services with no value.
+func wholeIPPassthrough(svc *v1.Service) bool {
+	if svc == nil || svc.Annotations == nil {
+		return true
+	}
+	return svc.Annotations[wholeIPAnnotation] != "false"
 }
 
 // cleanupRemovedServices performs an initial cleanup for removed services.
@@ -477,6 +522,23 @@ func (c *ServicesController) cleanupRemovedServices() error {
 	// Call InitialCleanup with the snapshot.
 	if err := c.Proxy.CleanupRules(keepMap); err != nil {
 		return fmt.Errorf("failed to perform initial cleanup: %w", err)
+	}
+	// Build per-svc port filter snapshot for services in non-passthrough mode.
+	keepFilters := make(map[string][]v1.ServicePort)
+	for _, se := range allServices {
+		if se.Service == nil || se.Endpoint == nil {
+			continue
+		}
+		if !hasValidServiceIP(se.Service) || !hasValidEndpointIP(se.Endpoint) {
+			continue
+		}
+		if wholeIPPassthrough(se.Service) {
+			continue
+		}
+		keepFilters[se.Service.Status.LoadBalancer.Ingress[0].IP] = se.Service.Spec.Ports
+	}
+	if err := c.Proxy.CleanupPortFilters(keepFilters); err != nil {
+		return fmt.Errorf("failed to perform port-filter cleanup: %w", err)
 	}
 	return nil
 }

--- a/pkg/controllers/services_controller.go
+++ b/pkg/controllers/services_controller.go
@@ -232,16 +232,17 @@ func (c *ServicesController) addServiceFunc(obj interface{}) {
 		se.Endpoint = ep
 		c.Services.Set(svc.Namespace, svc.Name, se)
 		svcIP := svc.Status.LoadBalancer.Ingress[0].IP
+		podIP := ep.Subsets[0].Addresses[0].IP
 		// Ensure NAT mapping rules are set.
-		c.Proxy.EnsureRules(svcIP, ep.Subsets[0].Addresses[0].IP)
+		c.Proxy.EnsureRules(svcIP, podIP)
 		// Apply (or remove) port filtering depending on annotation value.
 		if wholeIPPassthrough(svc) {
-			if err := c.Proxy.DeletePortFilter(svcIP); err != nil {
-				log.Error(err, "failed to delete port filter", "svcIP", svcIP)
+			if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
+				log.Error(err, "failed to delete port filter", "svcIP", svcIP, "podIP", podIP)
 			}
 		} else {
-			if err := c.Proxy.EnsurePortFilter(svcIP, svc.Spec.Ports); err != nil {
-				log.Error(err, "failed to ensure port filter", "svcIP", svcIP)
+			if err := c.Proxy.EnsurePortFilter(svcIP, podIP, svc.Spec.Ports); err != nil {
+				log.Error(err, "failed to ensure port filter", "svcIP", svcIP, "podIP", podIP)
 			}
 		}
 	}
@@ -264,10 +265,12 @@ func (c *ServicesController) deleteServiceFunc(obj interface{}) {
 		return
 	}
 
-	if err := c.Proxy.DeletePortFilter(se.Service.Status.LoadBalancer.Ingress[0].IP); err != nil {
-		log.Error(err, "failed to delete port filter on svc deletion", "svcIP", se.Service.Status.LoadBalancer.Ingress[0].IP)
+	svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
+	podIP := se.Endpoint.Subsets[0].Addresses[0].IP
+	if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
+		log.Error(err, "failed to delete port filter on svc deletion", "svcIP", svcIP, "podIP", podIP)
 	}
-	c.Proxy.DeleteRules(se.Service.Status.LoadBalancer.Ingress[0].IP, se.Endpoint.Subsets[0].Addresses[0].IP)
+	c.Proxy.DeleteRules(svcIP, podIP)
 	c.Services.Delete(svc.Namespace, svc.Name)
 }
 
@@ -284,13 +287,12 @@ func (c *ServicesController) updateServiceFunc(oldObj, newObj interface{}) {
 	if !hasWholeIPAnnotation(svc) {
 		if se, exists := c.Services.Get(svc.Namespace, svc.Name); exists {
 			if hasValidServiceIP(se.Service) && hasValidEndpointIP(se.Endpoint) {
-				if err := c.Proxy.DeletePortFilter(se.Service.Status.LoadBalancer.Ingress[0].IP); err != nil {
-					log.Error(err, "failed to delete port filter", "svcIP", se.Service.Status.LoadBalancer.Ingress[0].IP)
+				svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
+				podIP := se.Endpoint.Subsets[0].Addresses[0].IP
+				if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
+					log.Error(err, "failed to delete port filter", "svcIP", svcIP, "podIP", podIP)
 				}
-				c.Proxy.DeleteRules(
-					se.Service.Status.LoadBalancer.Ingress[0].IP,
-					se.Endpoint.Subsets[0].Addresses[0].IP,
-				)
+				c.Proxy.DeleteRules(svcIP, podIP)
 			}
 			c.Services.Delete(svc.Namespace, svc.Name)
 		}
@@ -301,13 +303,12 @@ func (c *ServicesController) updateServiceFunc(oldObj, newObj interface{}) {
 	if !hasValidServiceIP(svc) {
 		if se, exists := c.Services.Get(svc.Namespace, svc.Name); exists {
 			if hasValidServiceIP(se.Service) && hasValidEndpointIP(se.Endpoint) {
-				if err := c.Proxy.DeletePortFilter(se.Service.Status.LoadBalancer.Ingress[0].IP); err != nil {
-					log.Error(err, "failed to delete port filter", "svcIP", se.Service.Status.LoadBalancer.Ingress[0].IP)
+				svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
+				podIP := se.Endpoint.Subsets[0].Addresses[0].IP
+				if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
+					log.Error(err, "failed to delete port filter", "svcIP", svcIP, "podIP", podIP)
 				}
-				c.Proxy.DeleteRules(
-					se.Service.Status.LoadBalancer.Ingress[0].IP,
-					se.Endpoint.Subsets[0].Addresses[0].IP,
-				)
+				c.Proxy.DeleteRules(svcIP, podIP)
 			}
 			c.Services.Delete(svc.Namespace, svc.Name)
 		}
@@ -345,14 +346,15 @@ func (c *ServicesController) updateServiceFunc(oldObj, newObj interface{}) {
 	// At this point, both the Service and Endpoint have valid IPs.
 	// Ensure NAT mapping is up-to-date.
 	svcIP := svc.Status.LoadBalancer.Ingress[0].IP
-	c.Proxy.EnsureRules(svcIP, ep.Subsets[0].Addresses[0].IP)
+	podIP := ep.Subsets[0].Addresses[0].IP
+	c.Proxy.EnsureRules(svcIP, podIP)
 	if wholeIPPassthrough(svc) {
-		if err := c.Proxy.DeletePortFilter(svcIP); err != nil {
-			log.Error(err, "failed to delete port filter", "svcIP", svcIP)
+		if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
+			log.Error(err, "failed to delete port filter", "svcIP", svcIP, "podIP", podIP)
 		}
 	} else {
-		if err := c.Proxy.EnsurePortFilter(svcIP, svc.Spec.Ports); err != nil {
-			log.Error(err, "failed to ensure port filter", "svcIP", svcIP)
+		if err := c.Proxy.EnsurePortFilter(svcIP, podIP, svc.Spec.Ports); err != nil {
+			log.Error(err, "failed to ensure port filter", "svcIP", svcIP, "podIP", podIP)
 		}
 	}
 
@@ -524,7 +526,9 @@ func (c *ServicesController) cleanupRemovedServices() error {
 		return fmt.Errorf("failed to perform initial cleanup: %w", err)
 	}
 	// Build per-svc port filter snapshot for services in non-passthrough mode.
-	keepFilters := make(map[string][]v1.ServicePort)
+	// Keyed by svcIP (caller convenience); the entry carries podIP and ports
+	// because the actual nft set keys are pod IPs (post-DNAT match).
+	keepFilters := make(map[string]nat.PortFilterEntry)
 	for _, se := range allServices {
 		if se.Service == nil || se.Endpoint == nil {
 			continue
@@ -535,7 +539,10 @@ func (c *ServicesController) cleanupRemovedServices() error {
 		if wholeIPPassthrough(se.Service) {
 			continue
 		}
-		keepFilters[se.Service.Status.LoadBalancer.Ingress[0].IP] = se.Service.Spec.Ports
+		keepFilters[se.Service.Status.LoadBalancer.Ingress[0].IP] = nat.PortFilterEntry{
+			PodIP: se.Endpoint.Subsets[0].Addresses[0].IP,
+			Ports: se.Service.Spec.Ports,
+		}
 	}
 	if err := c.Proxy.CleanupPortFilters(keepFilters); err != nil {
 		return fmt.Errorf("failed to perform port-filter cleanup: %w", err)

--- a/pkg/controllers/services_controller.go
+++ b/pkg/controllers/services_controller.go
@@ -383,10 +383,19 @@ func (c *ServicesController) addEndpointFunc(obj interface{}) {
 
 	// If both the Service and the Endpoint have valid IPs, ensure NAT mapping rules.
 	if hasValidServiceIP(se.Service) && hasValidEndpointIP(ep) {
-		c.Proxy.EnsureRules(
-			se.Service.Status.LoadBalancer.Ingress[0].IP,
-			ep.Subsets[0].Addresses[0].IP,
-		)
+		svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
+		podIP := ep.Subsets[0].Addresses[0].IP
+		c.Proxy.EnsureRules(svcIP, podIP)
+		// Mirror the port-filter state to the new endpoint.
+		if wholeIPPassthrough(se.Service) {
+			if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
+				log.Error(err, "failed to delete port filter on endpoint add", "svcIP", svcIP, "podIP", podIP)
+			}
+		} else {
+			if err := c.Proxy.EnsurePortFilter(svcIP, podIP, se.Service.Spec.Ports); err != nil {
+				log.Error(err, "failed to ensure port filter on endpoint add", "svcIP", svcIP, "podIP", podIP)
+			}
+		}
 	}
 }
 
@@ -406,7 +415,12 @@ func (c *ServicesController) deleteEndpointFunc(obj interface{}) {
 	if !hasValidServiceIP(se.Service) || !hasValidEndpointIP(se.Endpoint) {
 		return
 	}
-	c.Proxy.DeleteRules(se.Service.Status.LoadBalancer.Ingress[0].IP, se.Endpoint.Subsets[0].Addresses[0].IP)
+	svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
+	podIP := se.Endpoint.Subsets[0].Addresses[0].IP
+	if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
+		log.Error(err, "failed to delete port filter on endpoint delete", "svcIP", svcIP, "podIP", podIP)
+	}
+	c.Proxy.DeleteRules(svcIP, podIP)
 	// Set the endpoint to nil.
 	c.Services.SetEndpoint(ep.Namespace, ep.Name, nil)
 }
@@ -426,7 +440,12 @@ func (c *ServicesController) updateEndpointFunc(oldObj, newObj interface{}) {
 	}
 	if !hasValidEndpointIP(ep) {
 		if hasValidServiceIP(se.Service) && hasValidEndpointIP(se.Endpoint) {
-			c.Proxy.DeleteRules(se.Service.Status.LoadBalancer.Ingress[0].IP, se.Endpoint.Subsets[0].Addresses[0].IP)
+			svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
+			oldPodIP := se.Endpoint.Subsets[0].Addresses[0].IP
+			if err := c.Proxy.DeletePortFilter(svcIP, oldPodIP); err != nil {
+				log.Error(err, "failed to delete port filter on endpoint invalidation", "svcIP", svcIP, "podIP", oldPodIP)
+			}
+			c.Proxy.DeleteRules(svcIP, oldPodIP)
 		}
 		c.Services.SetEndpoint(ep.Namespace, ep.Name, ep)
 		return
@@ -437,7 +456,18 @@ func (c *ServicesController) updateEndpointFunc(oldObj, newObj interface{}) {
 	if !hasValidEndpointIP(ep) {
 		return
 	}
-	c.Proxy.EnsureRules(se.Service.Status.LoadBalancer.Ingress[0].IP, ep.Subsets[0].Addresses[0].IP)
+	svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
+	podIP := ep.Subsets[0].Addresses[0].IP
+	c.Proxy.EnsureRules(svcIP, podIP)
+	if wholeIPPassthrough(se.Service) {
+		if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
+			log.Error(err, "failed to delete port filter on endpoint update", "svcIP", svcIP, "podIP", podIP)
+		}
+	} else {
+		if err := c.Proxy.EnsurePortFilter(svcIP, podIP, se.Service.Spec.Ports); err != nil {
+			log.Error(err, "failed to ensure port filter on endpoint update", "svcIP", svcIP, "podIP", podIP)
+		}
+	}
 	c.Services.SetEndpoint(ep.Namespace, ep.Name, ep)
 }
 

--- a/pkg/controllers/services_controller_test.go
+++ b/pkg/controllers/services_controller_test.go
@@ -1,0 +1,53 @@
+package controllers
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func svcWith(annot map[string]string) *v1.Service {
+	return &v1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: annot}}
+}
+
+func TestHasWholeIPAnnotation(t *testing.T) {
+	cases := []struct {
+		name   string
+		svc    *v1.Service
+		expect bool
+	}{
+		{"true value", svcWith(map[string]string{"networking.cozystack.io/wholeIP": "true"}), true},
+		{"false value", svcWith(map[string]string{"networking.cozystack.io/wholeIP": "false"}), true},
+		{"absent annotation", svcWith(map[string]string{}), false},
+		{"nil annotations", &v1.Service{}, false},
+		{"unrelated annotation", svcWith(map[string]string{"foo": "bar"}), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := hasWholeIPAnnotation(c.svc); got != c.expect {
+				t.Errorf("hasWholeIPAnnotation = %v, want %v", got, c.expect)
+			}
+		})
+	}
+}
+
+func TestWholeIPPassthrough(t *testing.T) {
+	cases := []struct {
+		name   string
+		svc    *v1.Service
+		expect bool
+	}{
+		{"true value", svcWith(map[string]string{"networking.cozystack.io/wholeIP": "true"}), true},
+		{"false value", svcWith(map[string]string{"networking.cozystack.io/wholeIP": "false"}), false},
+		{"absent annotation defaults to passthrough", svcWith(map[string]string{}), true},
+		{"nil annotations defaults to passthrough", &v1.Service{}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := wholeIPPassthrough(c.svc); got != c.expect {
+				t.Errorf("wholeIPPassthrough = %v, want %v", got, c.expect)
+			}
+		})
+	}
+}

--- a/pkg/proxy/dummy.go
+++ b/pkg/proxy/dummy.go
@@ -1,6 +1,10 @@
 package proxy
 
-import "fmt"
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 type DummyProxyProcessor struct{}
 
@@ -23,3 +27,21 @@ func (d *DummyProxyProcessor) CleanupRules(KeepMap map[string]string) error {
 	fmt.Println("CleanupRules called with KeepMap:", KeepMap)
 	return nil
 }
+
+func (d *DummyProxyProcessor) EnsurePortFilter(SvcIP string, Ports []corev1.ServicePort) error {
+	fmt.Printf("EnsurePortFilter called with SvcIP: %s, Ports: %+v\n", SvcIP, Ports)
+	return nil
+}
+
+func (d *DummyProxyProcessor) DeletePortFilter(SvcIP string) error {
+	fmt.Printf("DeletePortFilter called with SvcIP: %s\n", SvcIP)
+	return nil
+}
+
+func (d *DummyProxyProcessor) CleanupPortFilters(keep map[string][]corev1.ServicePort) error {
+	fmt.Printf("CleanupPortFilters called with %d entries\n", len(keep))
+	return nil
+}
+
+// Compile-time assertion that DummyProxyProcessor satisfies ProxyProcessor.
+var _ ProxyProcessor = (*DummyProxyProcessor)(nil)

--- a/pkg/proxy/dummy.go
+++ b/pkg/proxy/dummy.go
@@ -28,17 +28,17 @@ func (d *DummyProxyProcessor) CleanupRules(KeepMap map[string]string) error {
 	return nil
 }
 
-func (d *DummyProxyProcessor) EnsurePortFilter(SvcIP string, Ports []corev1.ServicePort) error {
-	fmt.Printf("EnsurePortFilter called with SvcIP: %s, Ports: %+v\n", SvcIP, Ports)
+func (d *DummyProxyProcessor) EnsurePortFilter(SvcIP, PodIP string, Ports []corev1.ServicePort) error {
+	fmt.Printf("EnsurePortFilter called with SvcIP: %s, PodIP: %s, Ports: %+v\n", SvcIP, PodIP, Ports)
 	return nil
 }
 
-func (d *DummyProxyProcessor) DeletePortFilter(SvcIP string) error {
-	fmt.Printf("DeletePortFilter called with SvcIP: %s\n", SvcIP)
+func (d *DummyProxyProcessor) DeletePortFilter(SvcIP, PodIP string) error {
+	fmt.Printf("DeletePortFilter called with SvcIP: %s, PodIP: %s\n", SvcIP, PodIP)
 	return nil
 }
 
-func (d *DummyProxyProcessor) CleanupPortFilters(keep map[string][]corev1.ServicePort) error {
+func (d *DummyProxyProcessor) CleanupPortFilters(keep map[string]PortFilterEntry) error {
 	fmt.Printf("CleanupPortFilters called with %d entries\n", len(keep))
 	return nil
 }

--- a/pkg/proxy/interface.go
+++ b/pkg/proxy/interface.go
@@ -9,18 +9,26 @@ type ProxyProcessor interface {
 	CleanupRules(KeepMap map[string]string) error
 
 	// EnsurePortFilter installs (or replaces) ingress port-filtering rules
-	// for the given service IP. Only TCP/UDP traffic destined to one of the
-	// listed ports will be accepted; any other port is dropped before the
-	// SNAT/DNAT rewrite. Pass an empty ports slice to disable filtering for
-	// SvcIP (equivalent to DeletePortFilter).
-	EnsurePortFilter(SvcIP string, Ports []corev1.ServicePort) error
+	// for the given pod IP. Only TCP/UDP traffic destined to one of the
+	// listed ports (in the post-DNAT pod IP) will be accepted; any other
+	// port is dropped after the early_snat rewrite. Pass an empty ports
+	// slice to disable filtering for the (svcIP, podIP) pair (equivalent
+	// to DeletePortFilter).
+	EnsurePortFilter(SvcIP, PodIP string, Ports []corev1.ServicePort) error
 
 	// DeletePortFilter removes any port-filtering rules previously installed
-	// for SvcIP. No-op if none exist.
-	DeletePortFilter(SvcIP string) error
+	// for the (svcIP, podIP) pair. No-op if none exist.
+	DeletePortFilter(SvcIP, PodIP string) error
 
 	// CleanupPortFilters keeps only the port-filter entries listed in
-	// keepFilters (svcIP → ports). Any stale entries are removed. Used at
-	// controller startup to reconcile against the live cluster snapshot.
-	CleanupPortFilters(keepFilters map[string][]corev1.ServicePort) error
+	// keepFilters. Any stale entries are removed. The PortFilterEntry struct
+	// carries both the pod IP (used as the actual nft key) and the ports.
+	CleanupPortFilters(keepFilters map[string]PortFilterEntry) error
+}
+
+// PortFilterEntry describes a port-filter desired state in the controller's
+// reconciliation snapshot. Keyed by service IP in the caller map.
+type PortFilterEntry struct {
+	PodIP string
+	Ports []corev1.ServicePort
 }

--- a/pkg/proxy/interface.go
+++ b/pkg/proxy/interface.go
@@ -1,8 +1,26 @@
 package proxy
 
+import corev1 "k8s.io/api/core/v1"
+
 type ProxyProcessor interface {
 	InitRules() error
 	EnsureRules(SvcIP, PodIP string) error
 	DeleteRules(SvcIP, PodIP string) error
 	CleanupRules(KeepMap map[string]string) error
+
+	// EnsurePortFilter installs (or replaces) ingress port-filtering rules
+	// for the given service IP. Only TCP/UDP traffic destined to one of the
+	// listed ports will be accepted; any other port is dropped before the
+	// SNAT/DNAT rewrite. Pass an empty ports slice to disable filtering for
+	// SvcIP (equivalent to DeletePortFilter).
+	EnsurePortFilter(SvcIP string, Ports []corev1.ServicePort) error
+
+	// DeletePortFilter removes any port-filtering rules previously installed
+	// for SvcIP. No-op if none exist.
+	DeletePortFilter(SvcIP string) error
+
+	// CleanupPortFilters keeps only the port-filter entries listed in
+	// keepFilters (svcIP → ports). Any stale entries are removed. Used at
+	// controller startup to reconcile against the live cluster snapshot.
+	CleanupPortFilters(keepFilters map[string][]corev1.ServicePort) error
 }

--- a/pkg/proxy/interface.go
+++ b/pkg/proxy/interface.go
@@ -11,7 +11,7 @@ type ProxyProcessor interface {
 	// EnsurePortFilter installs (or replaces) ingress port-filtering rules
 	// for the given pod IP. Only TCP/UDP traffic destined to one of the
 	// listed ports (in the post-DNAT pod IP) will be accepted; any other
-	// port is dropped after the early_snat rewrite. Pass an empty ports
+	// port is dropped after the ingress_dnat rewrite. Pass an empty ports
 	// slice to disable filtering for the (svcIP, podIP) pair (equivalent
 	// to DeletePortFilter).
 	EnsurePortFilter(SvcIP, PodIP string, Ports []corev1.ServicePort) error

--- a/pkg/proxy/nft.go
+++ b/pkg/proxy/nft.go
@@ -7,6 +7,7 @@ import (
 	"net"
 
 	"github.com/google/nftables"
+	"github.com/google/nftables/binaryutil"
 	"github.com/google/nftables/expr"
 	"golang.org/x/sys/unix"
 	corev1 "k8s.io/api/core/v1"
@@ -215,6 +216,38 @@ func (p *NFTProxyProcessor) InitRules() error {
 		},
 	})
 	log.Info("Added early_snat rules (SNAT and DNAT)")
+
+	// --- port_filter rule: bypass for established/related ---
+	// Idiomatic stateful firewall: any packet that belongs to an existing
+	// conntrack flow bypasses the per-port drop below. Without this, egress
+	// traffic from VMs in PortList mode would be broken: their return packets
+	// arrive with daddr=LB IP and dport=ephemeral source port, which would
+	// otherwise match the drop rule below. Conntrack state is populated by
+	// the nf_conntrack subsystem independently of nftables chain priorities,
+	// so this works correctly at priority -350.
+	p.conn.AddRule(&nftables.Rule{
+		Table: p.table,
+		Chain: p.portFilterCh,
+		Exprs: []expr.Any{
+			// Load ct state into reg 1 (uint32 bitmask).
+			&expr.Ct{Register: 1, SourceRegister: false, Key: expr.CtKeySTATE},
+			// Mask with (ESTABLISHED | RELATED). If any bit set, accept.
+			&expr.Bitwise{
+				SourceRegister: 1,
+				DestRegister:   1,
+				Len:            4,
+				Mask:           binaryutil.NativeEndian.PutUint32(expr.CtStateBitESTABLISHED | expr.CtStateBitRELATED),
+				Xor:            binaryutil.NativeEndian.PutUint32(0),
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpNeq,
+				Register: 1,
+				Data:     []byte{0, 0, 0, 0},
+			},
+			&expr.Verdict{Kind: expr.VerdictAccept},
+		},
+	})
+	log.Info("Added port_filter ct established,related accept rule")
 
 	// --- port_filter rule ---
 	// Equivalent to:

--- a/pkg/proxy/nft.go
+++ b/pkg/proxy/nft.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/nftables"
 	"github.com/google/nftables/expr"
 	"golang.org/x/sys/unix"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -21,9 +22,14 @@ type NFTProxyProcessor struct {
 	// Table "cozy_proxy" will contain all objects.
 	table *nftables.Table
 
-	// Sets and maps.
+	// IP-only NAT objects.
 	podSvcMap *nftables.Set // Map "pod_svc": maps pod IP → svc IP.
 	svcPodMap *nftables.Set // Map "svc_pod": maps svc IP → pod IP.
+
+	// Port-filtering objects.
+	filteredSvcs *nftables.Set   // set of svc IPs subject to port filtering.
+	allowedPorts *nftables.Set   // concat set: (ipv4_addr . inet_proto . inet_service).
+	portFilterCh *nftables.Chain // chain "port_filter" running before early_snat.
 }
 
 // InitRules initializes the nftables configuration in a single table "cozy_proxy".
@@ -80,6 +86,42 @@ func (p *NFTProxyProcessor) InitRules() error {
 	}
 	log.Info("Created svc_pod map", "map", p.svcPodMap.Name)
 
+	// --- Port filter sets ---
+	// Set "filtered_svcs": svc IPs subject to ingress port filtering.
+	p.filteredSvcs = &nftables.Set{
+		Table:   p.table,
+		Name:    "filtered_svcs",
+		KeyType: nftables.TypeIPAddr,
+	}
+	if err := p.conn.AddSet(p.filteredSvcs, nil); err != nil {
+		log.Error(err, "Could not add filtered_svcs set")
+		return fmt.Errorf("could not add filtered_svcs set: %v", err)
+	}
+	log.Info("Created filtered_svcs set", "set", p.filteredSvcs.Name)
+
+	// Set "allowed_ports": concat key (ipv4_addr . inet_proto . inet_service).
+	// Each component is padded to a 4-byte slot, total 12 bytes.
+	allowedKeyType, err := nftables.ConcatSetType(
+		nftables.TypeIPAddr,
+		nftables.TypeInetProto,
+		nftables.TypeInetService,
+	)
+	if err != nil {
+		log.Error(err, "Could not build allowed_ports key type")
+		return fmt.Errorf("could not build allowed_ports key type: %v", err)
+	}
+	p.allowedPorts = &nftables.Set{
+		Table:         p.table,
+		Name:          "allowed_ports",
+		KeyType:       allowedKeyType,
+		Concatenation: true,
+	}
+	if err := p.conn.AddSet(p.allowedPorts, nil); err != nil {
+		log.Error(err, "Could not add allowed_ports set")
+		return fmt.Errorf("could not add allowed_ports set: %v", err)
+	}
+	log.Info("Created allowed_ports concat set", "set", p.allowedPorts.Name)
+
 	// --- Delete Chains ---
 	chains, _ := p.conn.ListChains()
 	for _, chain := range chains {
@@ -89,6 +131,18 @@ func (p *NFTProxyProcessor) InitRules() error {
 	}
 
 	// --- Create Chains ---
+	// port_filter runs at priority -350, BEFORE early_snat (-300), so any
+	// drop verdict short-circuits before SNAT/DNAT rewrites.
+	portFilterPriority := nftables.ChainPriorityRef(-350)
+	p.portFilterCh = p.conn.AddChain(&nftables.Chain{
+		Name:     "port_filter",
+		Table:    p.table,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookPrerouting,
+		Priority: portFilterPriority,
+	})
+	log.Info("Created port_filter chain", "priority", -350)
+
 	earlySNAT := p.conn.AddChain(&nftables.Chain{
 		Name:     "early_snat",
 		Table:    p.table,
@@ -161,6 +215,59 @@ func (p *NFTProxyProcessor) InitRules() error {
 		},
 	})
 	log.Info("Added early_snat rules (SNAT and DNAT)")
+
+	// --- port_filter rule ---
+	// Equivalent to:
+	//   ip daddr @filtered_svcs ip daddr . meta l4proto . th dport != @allowed_ports drop
+	//
+	// Implementation: lay out the 12-byte concat key across NFT_REG32_00..02
+	// (register IDs 8, 9, 10), then a single inverted lookup against
+	// allowed_ports. Lookup reads s.KeyType.Bytes (12) bytes starting at the
+	// source register, so the three 4-byte slots must be contiguous.
+	p.conn.AddRule(&nftables.Rule{
+		Table: p.table,
+		Chain: p.portFilterCh,
+		Exprs: []expr.Any{
+			// 1. Gate: ip daddr in filtered_svcs (continue if matched).
+			&expr.Payload{
+				DestRegister: 1,
+				Base:         expr.PayloadBaseNetworkHeader,
+				Offset:       16, // IPv4 daddr
+				Len:          4,
+			},
+			&expr.Lookup{
+				SourceRegister: 1,
+				SetName:        p.filteredSvcs.Name,
+				SetID:          p.filteredSvcs.ID,
+			},
+			// 2. Build composite key (daddr . l4proto . dport) into reg32_00..02.
+			&expr.Payload{
+				DestRegister: unix.NFT_REG32_00,
+				Base:         expr.PayloadBaseNetworkHeader,
+				Offset:       16,
+				Len:          4,
+			},
+			&expr.Meta{
+				Key:      expr.MetaKeyL4PROTO,
+				Register: unix.NFT_REG32_01,
+			},
+			&expr.Payload{
+				DestRegister: unix.NFT_REG32_02,
+				Base:         expr.PayloadBaseTransportHeader,
+				Offset:       2, // dport (TCP and UDP both at byte 2)
+				Len:          2,
+			},
+			// 3. If (daddr, proto, dport) NOT in allowed_ports → drop.
+			&expr.Lookup{
+				SourceRegister: unix.NFT_REG32_00,
+				SetName:        p.allowedPorts.Name,
+				SetID:          p.allowedPorts.ID,
+				Invert:         true,
+			},
+			&expr.Verdict{Kind: expr.VerdictDrop},
+		},
+	})
+	log.Info("Added port_filter drop rule")
 
 	// Commit all changes.
 	if err := p.conn.Flush(); err != nil {
@@ -408,3 +515,149 @@ func (p *NFTProxyProcessor) CleanupRules(keepMap map[string]string) error {
 	log.Info("CleanupRules completed successfully")
 	return nil
 }
+
+// EnsurePortFilter installs ingress port filtering rules for svcIP. The given
+// ports are the only ones permitted; all other ingress traffic to svcIP is
+// dropped before the SNAT/DNAT chain runs. Idempotent.
+func (p *NFTProxyProcessor) EnsurePortFilter(svcIP string, ports []corev1.ServicePort) error {
+	log.Info("Ensuring port filter", "svcIP", svcIP, "portCount", len(ports))
+
+	parsedSvcIP := net.ParseIP(svcIP).To4()
+	if parsedSvcIP == nil {
+		return fmt.Errorf("invalid svcIP: %s", svcIP)
+	}
+
+	// 1. Remove any pre-existing entries in allowed_ports for svcIP so we can
+	// rebuild the tuple set cleanly (idempotent).
+	if err := p.removeAllowedPortsForSvc(parsedSvcIP); err != nil {
+		return err
+	}
+
+	// 2. Add svcIP to filtered_svcs (idempotent — Add ignores duplicates).
+	if err := p.conn.SetAddElements(p.filteredSvcs, []nftables.SetElement{{Key: parsedSvcIP}}); err != nil {
+		return fmt.Errorf("failed to add %s to filtered_svcs: %v", svcIP, err)
+	}
+
+	// 3. Add allowed (svcIP, proto, port) tuples.
+	for _, sp := range ports {
+		var protoByte byte
+		switch sp.Protocol {
+		case corev1.ProtocolTCP, "":
+			protoByte = unix.IPPROTO_TCP
+		case corev1.ProtocolUDP:
+			protoByte = unix.IPPROTO_UDP
+		default:
+			log.Info("Skipping unsupported protocol for port filter",
+				"svcIP", svcIP, "protocol", sp.Protocol)
+			continue
+		}
+		key := concatPortKey(parsedSvcIP, protoByte, uint16(sp.Port))
+		if err := p.conn.SetAddElements(p.allowedPorts, []nftables.SetElement{{Key: key}}); err != nil {
+			return fmt.Errorf("failed to add port tuple to allowed_ports (svc=%s proto=%v port=%d): %v",
+				svcIP, sp.Protocol, sp.Port, err)
+		}
+	}
+
+	if err := p.conn.Flush(); err != nil {
+		return fmt.Errorf("failed to flush EnsurePortFilter: %v", err)
+	}
+	log.Info("Port filter ensured", "svcIP", svcIP, "ports", ports)
+	return nil
+}
+
+// DeletePortFilter removes svcIP from filtered_svcs and clears any allowed
+// port entries for it. Tolerates ENOENT for clean idempotency.
+func (p *NFTProxyProcessor) DeletePortFilter(svcIP string) error {
+	log.Info("Deleting port filter", "svcIP", svcIP)
+	parsedSvcIP := net.ParseIP(svcIP).To4()
+	if parsedSvcIP == nil {
+		return fmt.Errorf("invalid svcIP: %s", svcIP)
+	}
+	if err := p.removeAllowedPortsForSvc(parsedSvcIP); err != nil {
+		return err
+	}
+	if err := p.conn.SetDeleteElements(p.filteredSvcs, []nftables.SetElement{{Key: parsedSvcIP}}); err != nil {
+		if !errors.Is(err, unix.ENOENT) {
+			return fmt.Errorf("failed to delete %s from filtered_svcs: %v", svcIP, err)
+		}
+	}
+	if err := p.conn.Flush(); err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			log.Info("DeletePortFilter ENOENT on flush — already gone", "svcIP", svcIP)
+			return nil
+		}
+		return fmt.Errorf("failed to flush DeletePortFilter: %v", err)
+	}
+	log.Info("Port filter deleted", "svcIP", svcIP)
+	return nil
+}
+
+// CleanupPortFilters reconciles port_filter state with the desired snapshot.
+// It removes any svcIP not in keep, and ensures filters for those that are.
+func (p *NFTProxyProcessor) CleanupPortFilters(keep map[string][]corev1.ServicePort) error {
+	log.Info("Starting CleanupPortFilters", "keepCount", len(keep))
+
+	desired := make(map[string]bool, len(keep))
+	for svcIP := range keep {
+		desired[svcIP] = true
+	}
+
+	current, err := p.conn.GetSetElements(p.filteredSvcs)
+	if err != nil {
+		return fmt.Errorf("failed to list filtered_svcs: %v", err)
+	}
+	for _, el := range current {
+		ipStr := net.IP(el.Key).String()
+		if !desired[ipStr] {
+			log.Info("Removing stale filtered_svc", "svcIP", ipStr)
+			if err := p.DeletePortFilter(ipStr); err != nil {
+				return fmt.Errorf("cleanup delete %s: %v", ipStr, err)
+			}
+		}
+	}
+	for svcIP, ports := range keep {
+		if err := p.EnsurePortFilter(svcIP, ports); err != nil {
+			return fmt.Errorf("cleanup ensure %s: %v", svcIP, err)
+		}
+	}
+	return nil
+}
+
+// concatPortKey returns the bytes for a (ipv4 . proto . port) concat set key.
+// nftables packs each component to 4-byte-aligned slots: 4 + 4 + 4 = 12 bytes.
+// proto goes in the low byte of slot 1, port goes in the first 2 bytes
+// (big-endian) of slot 2.
+func concatPortKey(ipv4 net.IP, proto byte, port uint16) []byte {
+	key := make([]byte, 12)
+	copy(key[0:4], ipv4.To4())
+	key[4] = proto
+	// bytes 5,6,7 stay zero (padding)
+	key[8] = byte(port >> 8)
+	key[9] = byte(port & 0xff)
+	// bytes 10,11 stay zero (padding)
+	return key
+}
+
+// removeAllowedPortsForSvc deletes all allowed_ports entries whose key prefix
+// matches parsedSvcIP. Used to make EnsurePortFilter idempotent.
+func (p *NFTProxyProcessor) removeAllowedPortsForSvc(parsedSvcIP net.IP) error {
+	elems, err := p.conn.GetSetElements(p.allowedPorts)
+	if err != nil {
+		return fmt.Errorf("failed to list allowed_ports: %v", err)
+	}
+	var toDel []nftables.SetElement
+	for _, el := range elems {
+		if len(el.Key) >= 4 && bytes.Equal(el.Key[:4], parsedSvcIP.To4()) {
+			toDel = append(toDel, nftables.SetElement{Key: el.Key})
+		}
+	}
+	if len(toDel) > 0 {
+		if err := p.conn.SetDeleteElements(p.allowedPorts, toDel); err != nil {
+			return fmt.Errorf("failed to delete stale allowed_ports for svc: %v", err)
+		}
+	}
+	return nil
+}
+
+// Compile-time assertion that NFTProxyProcessor satisfies ProxyProcessor.
+var _ ProxyProcessor = (*NFTProxyProcessor)(nil)

--- a/pkg/proxy/nft.go
+++ b/pkg/proxy/nft.go
@@ -594,7 +594,8 @@ func (p *NFTProxyProcessor) EnsurePortFilter(svcIP, podIP string, ports []corev1
 		return fmt.Errorf("failed to add %s to filtered_pods: %v", podIP, err)
 	}
 
-	// 3. Add allowed (podIP, proto, port) tuples.
+	// 3. Accumulate allowed (podIP, proto, port) tuples and add them in a single batch.
+	var elements []nftables.SetElement
 	for _, sp := range ports {
 		var protoByte byte
 		switch sp.Protocol {
@@ -607,10 +608,11 @@ func (p *NFTProxyProcessor) EnsurePortFilter(svcIP, podIP string, ports []corev1
 				"podIP", podIP, "protocol", sp.Protocol)
 			continue
 		}
-		key := concatPortKey(parsedPodIP, protoByte, uint16(sp.Port))
-		if err := p.conn.SetAddElements(p.allowedPorts, []nftables.SetElement{{Key: key}}); err != nil {
-			return fmt.Errorf("failed to add port tuple to allowed_ports (pod=%s proto=%v port=%d): %v",
-				podIP, sp.Protocol, sp.Port, err)
+		elements = append(elements, nftables.SetElement{Key: concatPortKey(parsedPodIP, protoByte, uint16(sp.Port))})
+	}
+	if len(elements) > 0 {
+		if err := p.conn.SetAddElements(p.allowedPorts, elements); err != nil {
+			return fmt.Errorf("failed to add port tuples to allowed_ports for pod %s: %v", podIP, err)
 		}
 	}
 
@@ -651,35 +653,111 @@ func (p *NFTProxyProcessor) DeletePortFilter(svcIP, podIP string) error {
 
 // CleanupPortFilters reconciles port_filter state with the desired snapshot.
 // The keep map is keyed by svcIP (for caller convenience) but the on-disk
-// nft set keys are pod IPs. We remove any pod IP currently in filtered_pods
-// that is not desired, then re-Ensure the desired ones.
+// nft set keys are pod IPs. The implementation is a single-pass diff: it
+// fetches current state once, computes additions and removals in memory,
+// batches SetAddElements / SetDeleteElements per set, and Flushes exactly
+// once.
 func (p *NFTProxyProcessor) CleanupPortFilters(keep map[string]PortFilterEntry) error {
 	log.Info("Starting CleanupPortFilters", "keepCount", len(keep))
 
-	desired := make(map[string]bool, len(keep))
+	// 1. Build desired state in memory.
+	desiredPods := make(map[string]bool, len(keep))
+	desiredPortKeys := make(map[string][]byte) // hex(key) → key (byte slice)
 	for _, entry := range keep {
-		desired[entry.PodIP] = true
+		parsedPodIP := net.ParseIP(entry.PodIP).To4()
+		if parsedPodIP == nil {
+			log.Info("Skipping invalid podIP in cleanup keep map", "podIP", entry.PodIP)
+			continue
+		}
+		desiredPods[entry.PodIP] = true
+		for _, sp := range entry.Ports {
+			var protoByte byte
+			switch sp.Protocol {
+			case corev1.ProtocolTCP, "":
+				protoByte = unix.IPPROTO_TCP
+			case corev1.ProtocolUDP:
+				protoByte = unix.IPPROTO_UDP
+			default:
+				continue
+			}
+			key := concatPortKey(parsedPodIP, protoByte, uint16(sp.Port))
+			desiredPortKeys[fmt.Sprintf("%x", key)] = key
+		}
 	}
 
-	current, err := p.conn.GetSetElements(p.filteredPods)
+	// 2. Fetch current state.
+	currentPods, err := p.conn.GetSetElements(p.filteredPods)
 	if err != nil {
 		return fmt.Errorf("failed to list filtered_pods: %v", err)
 	}
-	for _, el := range current {
+	currentPorts, err := p.conn.GetSetElements(p.allowedPorts)
+	if err != nil {
+		return fmt.Errorf("failed to list allowed_ports: %v", err)
+	}
+
+	// 3. Compute additions / removals.
+	var addPods, delPods []nftables.SetElement
+	var addPorts, delPorts []nftables.SetElement
+	seenPods := make(map[string]bool, len(currentPods))
+	for _, el := range currentPods {
 		ipStr := net.IP(el.Key).String()
-		if !desired[ipStr] {
-			log.Info("Removing stale filtered_pod", "podIP", ipStr)
-			// We don't have the original svcIP in current state; pass empty.
-			if err := p.DeletePortFilter("", ipStr); err != nil {
-				return fmt.Errorf("cleanup delete pod %s: %v", ipStr, err)
+		seenPods[ipStr] = true
+		if !desiredPods[ipStr] {
+			delPods = append(delPods, nftables.SetElement{Key: el.Key})
+		}
+	}
+	for podIPStr := range desiredPods {
+		if !seenPods[podIPStr] {
+			parsed := net.ParseIP(podIPStr).To4()
+			if parsed == nil {
+				continue
 			}
+			addPods = append(addPods, nftables.SetElement{Key: parsed})
 		}
 	}
-	for svcIP, entry := range keep {
-		if err := p.EnsurePortFilter(svcIP, entry.PodIP, entry.Ports); err != nil {
-			return fmt.Errorf("cleanup ensure %s: %v", svcIP, err)
+	seenPorts := make(map[string]bool, len(currentPorts))
+	for _, el := range currentPorts {
+		keyHex := fmt.Sprintf("%x", el.Key)
+		seenPorts[keyHex] = true
+		if _, want := desiredPortKeys[keyHex]; !want {
+			delPorts = append(delPorts, nftables.SetElement{Key: el.Key})
 		}
 	}
+	for keyHex, key := range desiredPortKeys {
+		if !seenPorts[keyHex] {
+			addPorts = append(addPorts, nftables.SetElement{Key: key})
+		}
+	}
+
+	// 4. Batch ops.
+	if len(delPods) > 0 {
+		if err := p.conn.SetDeleteElements(p.filteredPods, delPods); err != nil {
+			return fmt.Errorf("failed to delete stale filtered_pods: %v", err)
+		}
+	}
+	if len(delPorts) > 0 {
+		if err := p.conn.SetDeleteElements(p.allowedPorts, delPorts); err != nil {
+			return fmt.Errorf("failed to delete stale allowed_ports: %v", err)
+		}
+	}
+	if len(addPods) > 0 {
+		if err := p.conn.SetAddElements(p.filteredPods, addPods); err != nil {
+			return fmt.Errorf("failed to add filtered_pods: %v", err)
+		}
+	}
+	if len(addPorts) > 0 {
+		if err := p.conn.SetAddElements(p.allowedPorts, addPorts); err != nil {
+			return fmt.Errorf("failed to add allowed_ports: %v", err)
+		}
+	}
+
+	// 5. Single flush.
+	if err := p.conn.Flush(); err != nil {
+		return fmt.Errorf("failed to flush CleanupPortFilters: %v", err)
+	}
+	log.Info("CleanupPortFilters completed",
+		"addedPods", len(addPods), "removedPods", len(delPods),
+		"addedPorts", len(addPorts), "removedPorts", len(delPorts))
 	return nil
 }
 

--- a/pkg/proxy/nft.go
+++ b/pkg/proxy/nft.go
@@ -148,20 +148,20 @@ func (p *NFTProxyProcessor) InitRules() error {
 	})
 	log.Info("Created port_filter chain", "priority", "filter (0)")
 
-	earlySNAT := p.conn.AddChain(&nftables.Chain{
-		Name:     "early_snat",
+	egressSNAT := p.conn.AddChain(&nftables.Chain{
+		Name:     "egress_snat",
 		Table:    p.table,
 		Type:     nftables.ChainTypeFilter,
 		Hooknum:  nftables.ChainHookPrerouting,
 		Priority: nftables.ChainPriorityRaw,
 	})
-	log.Info("Created early_snat chain")
+	log.Info("Created egress_snat chain", "priority", "raw (-300)")
 
-	// --- Add Rules ---
-	// Add SNAT rule: ip saddr @pod ip saddr set ip saddr map @pod_svc
+	// SNAT rule: rewrite saddr from pod IP to svc IP (egress IP preservation).
+	// Runs BEFORE conntrack so the tracked tuple has saddr=LB_IP.
 	p.conn.AddRule(&nftables.Rule{
 		Table: p.table,
-		Chain: earlySNAT,
+		Chain: egressSNAT,
 		Exprs: []expr.Any{
 			&expr.Payload{
 				DestRegister: 1,
@@ -188,11 +188,23 @@ func (p *NFTProxyProcessor) InitRules() error {
 			},
 		},
 	})
+	log.Info("Added egress_snat saddr rewrite rule")
 
-	// Add DNAT rule: ip daddr @svc ip daddr set ip daddr map @svc_pod
+	ingressDNAT := p.conn.AddChain(&nftables.Chain{
+		Name:     "ingress_dnat",
+		Table:    p.table,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookPrerouting,
+		Priority: nftables.ChainPriorityMangle,
+	})
+	log.Info("Created ingress_dnat chain", "priority", "mangle (-150)")
+
+	// DNAT rule: rewrite daddr from svc IP to pod IP. Runs AFTER conntrack
+	// so conntrack records the original daddr=LB_IP and can correctly match
+	// reply packets of egress flows.
 	p.conn.AddRule(&nftables.Rule{
 		Table: p.table,
-		Chain: earlySNAT,
+		Chain: ingressDNAT,
 		Exprs: []expr.Any{
 			&expr.Payload{
 				DestRegister: 1,
@@ -219,7 +231,7 @@ func (p *NFTProxyProcessor) InitRules() error {
 			},
 		},
 	})
-	log.Info("Added early_snat rules (SNAT and DNAT)")
+	log.Info("Added ingress_dnat daddr rewrite rule")
 
 	// --- port_filter rule: bypass for established/related ---
 	// Idiomatic stateful firewall: any packet that belongs to an existing

--- a/pkg/proxy/nft.go
+++ b/pkg/proxy/nft.go
@@ -30,7 +30,7 @@ type NFTProxyProcessor struct {
 	// Port-filtering objects (post-DNAT, key on pod IP).
 	filteredPods *nftables.Set   // set of pod IPs subject to port filtering.
 	allowedPorts *nftables.Set   // concat set: (ipv4_addr . inet_proto . inet_service).
-	portFilterCh *nftables.Chain // chain "port_filter" running post-conntrack and post-early_snat.
+	portFilterCh *nftables.Chain // chain "port_filter" running post-conntrack and post-ingress_dnat.
 }
 
 // InitRules initializes the nftables configuration in a single table "cozy_proxy".
@@ -89,7 +89,7 @@ func (p *NFTProxyProcessor) InitRules() error {
 
 	// --- Port filter sets ---
 	// Set "filtered_pods": pod IPs subject to ingress port filtering.
-	// Keyed on pod IP because port_filter runs after early_snat has rewritten
+	// Keyed on pod IP because port_filter runs after ingress_dnat has rewritten
 	// daddr from LB IP to pod IP.
 	p.filteredPods = &nftables.Set{
 		Table:   p.table,
@@ -134,10 +134,10 @@ func (p *NFTProxyProcessor) InitRules() error {
 	}
 
 	// --- Create Chains ---
-	// port_filter runs at priority filter (0), AFTER early_snat (-300) and
-	// AFTER conntrack (-200). At this priority, daddr has been rewritten from
-	// LB IP to pod IP by early_snat, so the filter matches on pod IP. The
-	// "ct state established,related accept" rule below now works correctly
+	// port_filter runs at priority filter (0), AFTER conntrack (-200) and
+	// AFTER ingress_dnat (-150). At this priority, daddr has been rewritten
+	// from LB IP to pod IP by ingress_dnat, so the filter matches on pod IP.
+	// The "ct state established,related accept" rule below now works correctly
 	// because conntrack has tagged the packet by the time we evaluate it.
 	p.portFilterCh = p.conn.AddChain(&nftables.Chain{
 		Name:     "port_filter",
@@ -269,8 +269,8 @@ func (p *NFTProxyProcessor) InitRules() error {
 	// Equivalent to:
 	//   ip daddr @filtered_pods ip daddr . meta l4proto . th dport != @allowed_ports drop
 	//
-	// At priority filter (0), daddr has been rewritten by early_snat from the
-	// LB IP to the pod IP. Both the gate set (filtered_pods) and the
+	// At priority filter (0), daddr has been rewritten by ingress_dnat from
+	// the LB IP to the pod IP. Both the gate set (filtered_pods) and the
 	// allowed_ports composite key are therefore keyed on pod IP.
 	//
 	// Implementation: lay out the 12-byte concat key across NFT_REG32_00..02
@@ -285,7 +285,7 @@ func (p *NFTProxyProcessor) InitRules() error {
 			&expr.Payload{
 				DestRegister: 1,
 				Base:         expr.PayloadBaseNetworkHeader,
-				Offset:       16, // IPv4 daddr (post-early_snat: pod IP)
+				Offset:       16, // IPv4 daddr (post-ingress_dnat: pod IP)
 				Len:          4,
 			},
 			&expr.Lookup{
@@ -571,7 +571,7 @@ func (p *NFTProxyProcessor) CleanupRules(keepMap map[string]string) error {
 
 // EnsurePortFilter installs ingress port filtering rules for the given
 // (svcIP, podIP) pair. The actual nft set keys are pod IPs, because the
-// port_filter chain runs at priority filter (0), after early_snat has
+// port_filter chain runs at priority filter (0), after ingress_dnat has
 // rewritten daddr from svcIP to podIP. The given ports are the only ones
 // permitted on the post-DNAT pod IP; all other traffic destined to that
 // pod IP is dropped. Idempotent.

--- a/pkg/proxy/nft.go
+++ b/pkg/proxy/nft.go
@@ -27,10 +27,10 @@ type NFTProxyProcessor struct {
 	podSvcMap *nftables.Set // Map "pod_svc": maps pod IP → svc IP.
 	svcPodMap *nftables.Set // Map "svc_pod": maps svc IP → pod IP.
 
-	// Port-filtering objects.
-	filteredSvcs *nftables.Set   // set of svc IPs subject to port filtering.
+	// Port-filtering objects (post-DNAT, key on pod IP).
+	filteredPods *nftables.Set   // set of pod IPs subject to port filtering.
 	allowedPorts *nftables.Set   // concat set: (ipv4_addr . inet_proto . inet_service).
-	portFilterCh *nftables.Chain // chain "port_filter" running before early_snat.
+	portFilterCh *nftables.Chain // chain "port_filter" running post-conntrack and post-early_snat.
 }
 
 // InitRules initializes the nftables configuration in a single table "cozy_proxy".
@@ -88,17 +88,19 @@ func (p *NFTProxyProcessor) InitRules() error {
 	log.Info("Created svc_pod map", "map", p.svcPodMap.Name)
 
 	// --- Port filter sets ---
-	// Set "filtered_svcs": svc IPs subject to ingress port filtering.
-	p.filteredSvcs = &nftables.Set{
+	// Set "filtered_pods": pod IPs subject to ingress port filtering.
+	// Keyed on pod IP because port_filter runs after early_snat has rewritten
+	// daddr from LB IP to pod IP.
+	p.filteredPods = &nftables.Set{
 		Table:   p.table,
-		Name:    "filtered_svcs",
+		Name:    "filtered_pods",
 		KeyType: nftables.TypeIPAddr,
 	}
-	if err := p.conn.AddSet(p.filteredSvcs, nil); err != nil {
-		log.Error(err, "Could not add filtered_svcs set")
-		return fmt.Errorf("could not add filtered_svcs set: %v", err)
+	if err := p.conn.AddSet(p.filteredPods, nil); err != nil {
+		log.Error(err, "Could not add filtered_pods set")
+		return fmt.Errorf("could not add filtered_pods set: %v", err)
 	}
-	log.Info("Created filtered_svcs set", "set", p.filteredSvcs.Name)
+	log.Info("Created filtered_pods set", "set", p.filteredPods.Name)
 
 	// Set "allowed_ports": concat key (ipv4_addr . inet_proto . inet_service).
 	// Each component is padded to a 4-byte slot, total 12 bytes.
@@ -132,17 +134,19 @@ func (p *NFTProxyProcessor) InitRules() error {
 	}
 
 	// --- Create Chains ---
-	// port_filter runs at priority -350, BEFORE early_snat (-300), so any
-	// drop verdict short-circuits before SNAT/DNAT rewrites.
-	portFilterPriority := nftables.ChainPriorityRef(-350)
+	// port_filter runs at priority filter (0), AFTER early_snat (-300) and
+	// AFTER conntrack (-200). At this priority, daddr has been rewritten from
+	// LB IP to pod IP by early_snat, so the filter matches on pod IP. The
+	// "ct state established,related accept" rule below now works correctly
+	// because conntrack has tagged the packet by the time we evaluate it.
 	p.portFilterCh = p.conn.AddChain(&nftables.Chain{
 		Name:     "port_filter",
 		Table:    p.table,
 		Type:     nftables.ChainTypeFilter,
 		Hooknum:  nftables.ChainHookPrerouting,
-		Priority: portFilterPriority,
+		Priority: nftables.ChainPriorityFilter,
 	})
-	log.Info("Created port_filter chain", "priority", -350)
+	log.Info("Created port_filter chain", "priority", "filter (0)")
 
 	earlySNAT := p.conn.AddChain(&nftables.Chain{
 		Name:     "early_snat",
@@ -222,9 +226,9 @@ func (p *NFTProxyProcessor) InitRules() error {
 	// conntrack flow bypasses the per-port drop below. Without this, egress
 	// traffic from VMs in PortList mode would be broken: their return packets
 	// arrive with daddr=LB IP and dport=ephemeral source port, which would
-	// otherwise match the drop rule below. Conntrack state is populated by
-	// the nf_conntrack subsystem independently of nftables chain priorities,
-	// so this works correctly at priority -350.
+	// otherwise match the drop rule below. Because port_filter runs at
+	// priority filter (0), conntrack (priority -200) has already evaluated
+	// the packet and ct state is correctly populated.
 	p.conn.AddRule(&nftables.Rule{
 		Table: p.table,
 		Chain: p.portFilterCh,
@@ -251,7 +255,11 @@ func (p *NFTProxyProcessor) InitRules() error {
 
 	// --- port_filter rule ---
 	// Equivalent to:
-	//   ip daddr @filtered_svcs ip daddr . meta l4proto . th dport != @allowed_ports drop
+	//   ip daddr @filtered_pods ip daddr . meta l4proto . th dport != @allowed_ports drop
+	//
+	// At priority filter (0), daddr has been rewritten by early_snat from the
+	// LB IP to the pod IP. Both the gate set (filtered_pods) and the
+	// allowed_ports composite key are therefore keyed on pod IP.
 	//
 	// Implementation: lay out the 12-byte concat key across NFT_REG32_00..02
 	// (register IDs 8, 9, 10), then a single inverted lookup against
@@ -261,17 +269,17 @@ func (p *NFTProxyProcessor) InitRules() error {
 		Table: p.table,
 		Chain: p.portFilterCh,
 		Exprs: []expr.Any{
-			// 1. Gate: ip daddr in filtered_svcs (continue if matched).
+			// 1. Gate: ip daddr in filtered_pods (continue if matched).
 			&expr.Payload{
 				DestRegister: 1,
 				Base:         expr.PayloadBaseNetworkHeader,
-				Offset:       16, // IPv4 daddr
+				Offset:       16, // IPv4 daddr (post-early_snat: pod IP)
 				Len:          4,
 			},
 			&expr.Lookup{
 				SourceRegister: 1,
-				SetName:        p.filteredSvcs.Name,
-				SetID:          p.filteredSvcs.ID,
+				SetName:        p.filteredPods.Name,
+				SetID:          p.filteredPods.ID,
 			},
 			// 2. Build composite key (daddr . l4proto . dport) into reg32_00..02.
 			&expr.Payload{
@@ -549,29 +557,32 @@ func (p *NFTProxyProcessor) CleanupRules(keepMap map[string]string) error {
 	return nil
 }
 
-// EnsurePortFilter installs ingress port filtering rules for svcIP. The given
-// ports are the only ones permitted; all other ingress traffic to svcIP is
-// dropped before the SNAT/DNAT chain runs. Idempotent.
-func (p *NFTProxyProcessor) EnsurePortFilter(svcIP string, ports []corev1.ServicePort) error {
-	log.Info("Ensuring port filter", "svcIP", svcIP, "portCount", len(ports))
+// EnsurePortFilter installs ingress port filtering rules for the given
+// (svcIP, podIP) pair. The actual nft set keys are pod IPs, because the
+// port_filter chain runs at priority filter (0), after early_snat has
+// rewritten daddr from svcIP to podIP. The given ports are the only ones
+// permitted on the post-DNAT pod IP; all other traffic destined to that
+// pod IP is dropped. Idempotent.
+func (p *NFTProxyProcessor) EnsurePortFilter(svcIP, podIP string, ports []corev1.ServicePort) error {
+	log.Info("Ensuring port filter", "svcIP", svcIP, "podIP", podIP, "portCount", len(ports))
 
-	parsedSvcIP := net.ParseIP(svcIP).To4()
-	if parsedSvcIP == nil {
-		return fmt.Errorf("invalid svcIP: %s", svcIP)
+	parsedPodIP := net.ParseIP(podIP).To4()
+	if parsedPodIP == nil {
+		return fmt.Errorf("invalid podIP: %s", podIP)
 	}
 
-	// 1. Remove any pre-existing entries in allowed_ports for svcIP so we can
+	// 1. Remove any pre-existing entries in allowed_ports for podIP so we can
 	// rebuild the tuple set cleanly (idempotent).
-	if err := p.removeAllowedPortsForSvc(parsedSvcIP); err != nil {
+	if err := p.removeAllowedPortsForPod(parsedPodIP); err != nil {
 		return err
 	}
 
-	// 2. Add svcIP to filtered_svcs (idempotent — Add ignores duplicates).
-	if err := p.conn.SetAddElements(p.filteredSvcs, []nftables.SetElement{{Key: parsedSvcIP}}); err != nil {
-		return fmt.Errorf("failed to add %s to filtered_svcs: %v", svcIP, err)
+	// 2. Add podIP to filtered_pods (idempotent — Add ignores duplicates).
+	if err := p.conn.SetAddElements(p.filteredPods, []nftables.SetElement{{Key: parsedPodIP}}); err != nil {
+		return fmt.Errorf("failed to add %s to filtered_pods: %v", podIP, err)
 	}
 
-	// 3. Add allowed (svcIP, proto, port) tuples.
+	// 3. Add allowed (podIP, proto, port) tuples.
 	for _, sp := range ports {
 		var protoByte byte
 		switch sp.Protocol {
@@ -581,75 +592,79 @@ func (p *NFTProxyProcessor) EnsurePortFilter(svcIP string, ports []corev1.Servic
 			protoByte = unix.IPPROTO_UDP
 		default:
 			log.Info("Skipping unsupported protocol for port filter",
-				"svcIP", svcIP, "protocol", sp.Protocol)
+				"podIP", podIP, "protocol", sp.Protocol)
 			continue
 		}
-		key := concatPortKey(parsedSvcIP, protoByte, uint16(sp.Port))
+		key := concatPortKey(parsedPodIP, protoByte, uint16(sp.Port))
 		if err := p.conn.SetAddElements(p.allowedPorts, []nftables.SetElement{{Key: key}}); err != nil {
-			return fmt.Errorf("failed to add port tuple to allowed_ports (svc=%s proto=%v port=%d): %v",
-				svcIP, sp.Protocol, sp.Port, err)
+			return fmt.Errorf("failed to add port tuple to allowed_ports (pod=%s proto=%v port=%d): %v",
+				podIP, sp.Protocol, sp.Port, err)
 		}
 	}
 
 	if err := p.conn.Flush(); err != nil {
 		return fmt.Errorf("failed to flush EnsurePortFilter: %v", err)
 	}
-	log.Info("Port filter ensured", "svcIP", svcIP, "ports", ports)
+	log.Info("Port filter ensured", "svcIP", svcIP, "podIP", podIP, "ports", ports)
 	return nil
 }
 
-// DeletePortFilter removes svcIP from filtered_svcs and clears any allowed
-// port entries for it. Tolerates ENOENT for clean idempotency.
-func (p *NFTProxyProcessor) DeletePortFilter(svcIP string) error {
-	log.Info("Deleting port filter", "svcIP", svcIP)
-	parsedSvcIP := net.ParseIP(svcIP).To4()
-	if parsedSvcIP == nil {
-		return fmt.Errorf("invalid svcIP: %s", svcIP)
+// DeletePortFilter removes podIP from filtered_pods and clears any allowed
+// port entries for it. svcIP is used only for logging context. Tolerates
+// ENOENT for clean idempotency.
+func (p *NFTProxyProcessor) DeletePortFilter(svcIP, podIP string) error {
+	log.Info("Deleting port filter", "svcIP", svcIP, "podIP", podIP)
+	parsedPodIP := net.ParseIP(podIP).To4()
+	if parsedPodIP == nil {
+		return fmt.Errorf("invalid podIP: %s", podIP)
 	}
-	if err := p.removeAllowedPortsForSvc(parsedSvcIP); err != nil {
+	if err := p.removeAllowedPortsForPod(parsedPodIP); err != nil {
 		return err
 	}
-	if err := p.conn.SetDeleteElements(p.filteredSvcs, []nftables.SetElement{{Key: parsedSvcIP}}); err != nil {
+	if err := p.conn.SetDeleteElements(p.filteredPods, []nftables.SetElement{{Key: parsedPodIP}}); err != nil {
 		if !errors.Is(err, unix.ENOENT) {
-			return fmt.Errorf("failed to delete %s from filtered_svcs: %v", svcIP, err)
+			return fmt.Errorf("failed to delete %s from filtered_pods: %v", podIP, err)
 		}
 	}
 	if err := p.conn.Flush(); err != nil {
 		if errors.Is(err, unix.ENOENT) {
-			log.Info("DeletePortFilter ENOENT on flush — already gone", "svcIP", svcIP)
+			log.Info("DeletePortFilter ENOENT on flush — already gone", "podIP", podIP)
 			return nil
 		}
 		return fmt.Errorf("failed to flush DeletePortFilter: %v", err)
 	}
-	log.Info("Port filter deleted", "svcIP", svcIP)
+	log.Info("Port filter deleted", "svcIP", svcIP, "podIP", podIP)
 	return nil
 }
 
 // CleanupPortFilters reconciles port_filter state with the desired snapshot.
-// It removes any svcIP not in keep, and ensures filters for those that are.
-func (p *NFTProxyProcessor) CleanupPortFilters(keep map[string][]corev1.ServicePort) error {
+// The keep map is keyed by svcIP (for caller convenience) but the on-disk
+// nft set keys are pod IPs. We remove any pod IP currently in filtered_pods
+// that is not desired, then re-Ensure the desired ones.
+func (p *NFTProxyProcessor) CleanupPortFilters(keep map[string]PortFilterEntry) error {
 	log.Info("Starting CleanupPortFilters", "keepCount", len(keep))
 
 	desired := make(map[string]bool, len(keep))
-	for svcIP := range keep {
-		desired[svcIP] = true
+	for _, entry := range keep {
+		desired[entry.PodIP] = true
 	}
 
-	current, err := p.conn.GetSetElements(p.filteredSvcs)
+	current, err := p.conn.GetSetElements(p.filteredPods)
 	if err != nil {
-		return fmt.Errorf("failed to list filtered_svcs: %v", err)
+		return fmt.Errorf("failed to list filtered_pods: %v", err)
 	}
 	for _, el := range current {
 		ipStr := net.IP(el.Key).String()
 		if !desired[ipStr] {
-			log.Info("Removing stale filtered_svc", "svcIP", ipStr)
-			if err := p.DeletePortFilter(ipStr); err != nil {
-				return fmt.Errorf("cleanup delete %s: %v", ipStr, err)
+			log.Info("Removing stale filtered_pod", "podIP", ipStr)
+			// We don't have the original svcIP in current state; pass empty.
+			if err := p.DeletePortFilter("", ipStr); err != nil {
+				return fmt.Errorf("cleanup delete pod %s: %v", ipStr, err)
 			}
 		}
 	}
-	for svcIP, ports := range keep {
-		if err := p.EnsurePortFilter(svcIP, ports); err != nil {
+	for svcIP, entry := range keep {
+		if err := p.EnsurePortFilter(svcIP, entry.PodIP, entry.Ports); err != nil {
 			return fmt.Errorf("cleanup ensure %s: %v", svcIP, err)
 		}
 	}
@@ -671,22 +686,22 @@ func concatPortKey(ipv4 net.IP, proto byte, port uint16) []byte {
 	return key
 }
 
-// removeAllowedPortsForSvc deletes all allowed_ports entries whose key prefix
-// matches parsedSvcIP. Used to make EnsurePortFilter idempotent.
-func (p *NFTProxyProcessor) removeAllowedPortsForSvc(parsedSvcIP net.IP) error {
+// removeAllowedPortsForPod deletes all allowed_ports entries whose key prefix
+// matches parsedPodIP. Used to make EnsurePortFilter idempotent.
+func (p *NFTProxyProcessor) removeAllowedPortsForPod(parsedPodIP net.IP) error {
 	elems, err := p.conn.GetSetElements(p.allowedPorts)
 	if err != nil {
 		return fmt.Errorf("failed to list allowed_ports: %v", err)
 	}
 	var toDel []nftables.SetElement
 	for _, el := range elems {
-		if len(el.Key) >= 4 && bytes.Equal(el.Key[:4], parsedSvcIP.To4()) {
+		if len(el.Key) >= 4 && bytes.Equal(el.Key[:4], parsedPodIP.To4()) {
 			toDel = append(toDel, nftables.SetElement{Key: el.Key})
 		}
 	}
 	if len(toDel) > 0 {
 		if err := p.conn.SetDeleteElements(p.allowedPorts, toDel); err != nil {
-			return fmt.Errorf("failed to delete stale allowed_ports for svc: %v", err)
+			return fmt.Errorf("failed to delete stale allowed_ports for pod: %v", err)
 		}
 	}
 	return nil

--- a/pkg/proxy/nft.go
+++ b/pkg/proxy/nft.go
@@ -576,6 +576,14 @@ func (p *NFTProxyProcessor) CleanupRules(keepMap map[string]string) error {
 // permitted on the post-DNAT pod IP; all other traffic destined to that
 // pod IP is dropped. Idempotent.
 func (p *NFTProxyProcessor) EnsurePortFilter(svcIP, podIP string, ports []corev1.ServicePort) error {
+	// Empty ports list is documented as equivalent to DeletePortFilter:
+	// the caller wants to disable filtering for this pod entirely. Without
+	// this short-circuit we would add the pod to filtered_pods with no
+	// matching allowed_ports entries, which would drop every ingress packet
+	// to the pod IP — the opposite of "no filter".
+	if len(ports) == 0 {
+		return p.DeletePortFilter(svcIP, podIP)
+	}
 	log.Info("Ensuring port filter", "svcIP", svcIP, "podIP", podIP, "portCount", len(ports))
 
 	parsedPodIP := net.ParseIP(podIP).To4()

--- a/pkg/proxy/nft_test.go
+++ b/pkg/proxy/nft_test.go
@@ -1,0 +1,54 @@
+//go:build linux
+
+package proxy
+
+import (
+	"bytes"
+	"net"
+	"testing"
+)
+
+func TestConcatPortKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		ip    string
+		proto byte
+		port  uint16
+		want  []byte
+	}{
+		{
+			name:  "tcp/80",
+			ip:    "10.0.0.1",
+			proto: 6,
+			port:  80,
+			want:  []byte{10, 0, 0, 1, 6, 0, 0, 0, 0, 80, 0, 0},
+		},
+		{
+			name:  "udp/53",
+			ip:    "192.168.1.10",
+			proto: 17,
+			port:  53,
+			want:  []byte{192, 168, 1, 10, 17, 0, 0, 0, 0, 53, 0, 0},
+		},
+		{
+			name:  "high port BE",
+			ip:    "172.16.0.5",
+			proto: 6,
+			port:  50000, // 0xC350 → bytes 195, 80
+			want:  []byte{172, 16, 0, 5, 6, 0, 0, 0, 195, 80, 0, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := concatPortKey(net.ParseIP(tt.ip), tt.proto, tt.port)
+			if !bytes.Equal(got, tt.want) {
+				t.Errorf("concatPortKey(%s, %d, %d) = %v, want %v",
+					tt.ip, tt.proto, tt.port, got, tt.want)
+			}
+			if len(got) != 12 {
+				t.Errorf("expected 12-byte key, got %d bytes", len(got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Adds an opt-in ingress port filter to `cozy-proxy`, so that a Service annotated with `networking.cozystack.io/wholeIP: "false"` only accepts TCP/UDP traffic on the ports listed in `Service.spec.ports`. Traffic to any other port destined to that LB IP is dropped before NAT rewrite. Egress IP preservation is preserved in both modes.

The existing wholeIP semantics (annotation `"true"` or absent → passthrough) is unchanged, so existing deployments are not affected.

## Why

The companion chart `vm-instance` in `cozystack/cozystack` ships an `externalMethod: PortList` mode that's documented as filtering ingress to declared ports. That mode is currently non-functional because cozy-proxy installs an IP-only DNAT (no port awareness) regardless of `Service.spec.ports`. Verified empirically on Cozystack v1.3.0 — see https://github.com/cozystack/cozystack/issues/<TBD-cozystack-issue> for the user-facing report.

## How

- **Datapath redesign — split the rewrite into two chains:**
  - `egress_snat` at priority `raw` (-300): saddr rewrite via `pod_svc` map, runs before conntrack so the recorded tuple has saddr=LB_IP.
  - `ingress_dnat` at priority `mangle` (-150): daddr rewrite via `svc_pod` map, runs after conntrack so reply packets of egress flows are matched correctly. This was previously combined with egress_snat in a single chain at raw, which broke conntrack matching for return packets.
- **New port_filter chain at priority `filter` (0):**
  - `ct state established,related accept` for stateful pass-through of return packets.
  - `ip daddr @filtered_pods ip daddr . meta l4proto . th dport != @allowed_ports drop` to enforce the port whitelist for new connections.
- **Two new objects in table `cozy_proxy`:**
  - `filtered_pods` (set of pod IPs, post-DNAT) opted into filtering.
  - `allowed_ports` (concat set: `ipv4_addr . inet_proto . inet_service`) listing allowed `(podIP, proto, port)` tuples.
- **New methods on `proxy.ProxyProcessor`:** `EnsurePortFilter(svcIP, podIP, ports)`, `DeletePortFilter(svcIP, podIP)`, `CleanupPortFilters(map[string]PortFilterEntry)`.
- **Controller helpers:** existing `hasWholeIPAnnotation` is broadened to "any value triggers management"; new `wholeIPPassthrough` returns false only for `"false"`. Backward-compatible with existing deployments.

## Test plan

- [x] Unit tests for `wholeIPPassthrough` and `hasWholeIPAnnotation` (added)
- [x] Built `cozy-proxy:portfilter-dev` (linux/amd64) and deployed on a 3-node Talos lab (Cozystack v1.3.0, Cilium 1.19)
- [x] Patched a Service to `wholeIP: "false"` with `spec.ports: [22]`: only port 22 reachable from outside, ports 80/443/8080/9999 filtered (verified with nmap + bash /dev/tcp)
- [x] WholeIP-annotated Service unchanged: all listening ports reachable
- [x] Egress IP preservation works in both modes (TCP curl + UDP DNS): VM sources its own LB IP via SNAT, conntrack tracks return packets correctly
- [x] `nft list table ip cozy_proxy` confirms the expected ruleset (egress_snat raw, ingress_dnat mangle, port_filter filter with stateful accept + per-port drop)

## Release note

```release-note
[cozy-proxy] Add per-service ingress port filtering via the wholeIP annotation: with `wholeIP: "false"`, cozy-proxy drops ingress traffic to the LB IP on ports not listed in `Service.spec.ports`. The default `wholeIP: "true"` (or absent) keeps the previous all-ports passthrough behavior. The existing IP rewrite chain `early_snat` is split into `egress_snat` (raw) and `ingress_dnat` (mangle) to make the datapath conntrack-aware. Required to enable a working `externalMethod: PortList` in the cozystack `vm-instance` chart.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Services now support value-driven `networking.cozystack.io/wholeIP` annotation modes (`"true"`, `"false"`, or absent)
  * Port-based filtering for services with conntrack-aware traffic handling

* **Documentation**
  * Updated documentation describing the wholeIP annotation configuration modes and corresponding datapath behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->