### PR TITLE
feat: add allowICMP annotation for port-filter mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ annotation. The annotation value selects the ingress mode:
 In both managed modes, egress traffic from the backend pod is SNATed to the
 LoadBalancer IP for source-IP preservation.
 
+The optional `networking.cozystack.io/allowICMP: "true"` annotation, only
+meaningful in port-filter mode (`wholeIP: "false"`), accepts ICMP traffic
+toward the backend pod IP that would otherwise be dropped by the per-port
+filter. Without it, all ICMP to a port-filtered pod is dropped — which also
+blocks `ping`, **PMTU discovery** (ICMP "fragmentation needed"), and ICMP
+unreachable signalling. Recommended for any service where path-MTU mismatches
+or observability matter.
+
 ## Datapath
 
 The nftables ruleset placed in table `ip cozy_proxy` consists of:
@@ -55,7 +63,9 @@ The nftables ruleset placed in table `ip cozy_proxy` consists of:
   `(daddr, l4proto, dport)` is not in `allowed_ports`. The chain accepts
   packets in conntrack states `established` or `related` first, so reply
   packets of egress flows bypass the filter even when their dport is the VM's
-  ephemeral source port.
+  ephemeral source port. ICMP is dropped by default; if the
+  `allowICMP: "true"` annotation is set, the pod IP is added to
+  `icmp_allowed_pods` and ICMP toward it is accepted before the drop rule.
 
 ## Installation
 

--- a/pkg/controllers/services_controller.go
+++ b/pkg/controllers/services_controller.go
@@ -235,16 +235,7 @@ func (c *ServicesController) addServiceFunc(obj interface{}) {
 		podIP := ep.Subsets[0].Addresses[0].IP
 		// Ensure NAT mapping rules are set.
 		c.Proxy.EnsureRules(svcIP, podIP)
-		// Apply (or remove) port filtering depending on annotation value.
-		if wholeIPPassthrough(svc) {
-			if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
-				log.Error(err, "failed to delete port filter", "svcIP", svcIP, "podIP", podIP)
-			}
-		} else {
-			if err := c.Proxy.EnsurePortFilter(svcIP, podIP, svc.Spec.Ports); err != nil {
-				log.Error(err, "failed to ensure port filter", "svcIP", svcIP, "podIP", podIP)
-			}
-		}
+		c.reconcilePortFilter(svc, svcIP, podIP, "on svc add")
 	}
 }
 
@@ -267,9 +258,7 @@ func (c *ServicesController) deleteServiceFunc(obj interface{}) {
 
 	svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
 	podIP := se.Endpoint.Subsets[0].Addresses[0].IP
-	if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
-		log.Error(err, "failed to delete port filter on svc deletion", "svcIP", svcIP, "podIP", podIP)
-	}
+	c.clearPortFilter(svcIP, podIP, "on svc deletion")
 	c.Proxy.DeleteRules(svcIP, podIP)
 	c.Services.Delete(svc.Namespace, svc.Name)
 }
@@ -289,9 +278,7 @@ func (c *ServicesController) updateServiceFunc(oldObj, newObj interface{}) {
 			if hasValidServiceIP(se.Service) && hasValidEndpointIP(se.Endpoint) {
 				svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
 				podIP := se.Endpoint.Subsets[0].Addresses[0].IP
-				if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
-					log.Error(err, "failed to delete port filter", "svcIP", svcIP, "podIP", podIP)
-				}
+				c.clearPortFilter(svcIP, podIP, "on annotation removal")
 				c.Proxy.DeleteRules(svcIP, podIP)
 			}
 			c.Services.Delete(svc.Namespace, svc.Name)
@@ -305,9 +292,7 @@ func (c *ServicesController) updateServiceFunc(oldObj, newObj interface{}) {
 			if hasValidServiceIP(se.Service) && hasValidEndpointIP(se.Endpoint) {
 				svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
 				podIP := se.Endpoint.Subsets[0].Addresses[0].IP
-				if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
-					log.Error(err, "failed to delete port filter", "svcIP", svcIP, "podIP", podIP)
-				}
+				c.clearPortFilter(svcIP, podIP, "on svc IP loss")
 				c.Proxy.DeleteRules(svcIP, podIP)
 			}
 			c.Services.Delete(svc.Namespace, svc.Name)
@@ -348,15 +333,7 @@ func (c *ServicesController) updateServiceFunc(oldObj, newObj interface{}) {
 	svcIP := svc.Status.LoadBalancer.Ingress[0].IP
 	podIP := ep.Subsets[0].Addresses[0].IP
 	c.Proxy.EnsureRules(svcIP, podIP)
-	if wholeIPPassthrough(svc) {
-		if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
-			log.Error(err, "failed to delete port filter", "svcIP", svcIP, "podIP", podIP)
-		}
-	} else {
-		if err := c.Proxy.EnsurePortFilter(svcIP, podIP, svc.Spec.Ports); err != nil {
-			log.Error(err, "failed to ensure port filter", "svcIP", svcIP, "podIP", podIP)
-		}
-	}
+	c.reconcilePortFilter(svc, svcIP, podIP, "on svc update")
 
 	// Update or add the service mapping with the new endpoint.
 	c.Services.Set(svc.Namespace, svc.Name, &ServiceEndpoints{Service: svc, Endpoint: ep})
@@ -386,16 +363,7 @@ func (c *ServicesController) addEndpointFunc(obj interface{}) {
 		svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
 		podIP := ep.Subsets[0].Addresses[0].IP
 		c.Proxy.EnsureRules(svcIP, podIP)
-		// Mirror the port-filter state to the new endpoint.
-		if wholeIPPassthrough(se.Service) {
-			if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
-				log.Error(err, "failed to delete port filter on endpoint add", "svcIP", svcIP, "podIP", podIP)
-			}
-		} else {
-			if err := c.Proxy.EnsurePortFilter(svcIP, podIP, se.Service.Spec.Ports); err != nil {
-				log.Error(err, "failed to ensure port filter on endpoint add", "svcIP", svcIP, "podIP", podIP)
-			}
-		}
+		c.reconcilePortFilter(se.Service, svcIP, podIP, "on endpoint add")
 	}
 }
 
@@ -417,9 +385,7 @@ func (c *ServicesController) deleteEndpointFunc(obj interface{}) {
 	}
 	svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
 	podIP := se.Endpoint.Subsets[0].Addresses[0].IP
-	if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
-		log.Error(err, "failed to delete port filter on endpoint delete", "svcIP", svcIP, "podIP", podIP)
-	}
+	c.clearPortFilter(svcIP, podIP, "on endpoint delete")
 	c.Proxy.DeleteRules(svcIP, podIP)
 	// Set the endpoint to nil.
 	c.Services.SetEndpoint(ep.Namespace, ep.Name, nil)
@@ -442,9 +408,7 @@ func (c *ServicesController) updateEndpointFunc(oldObj, newObj interface{}) {
 		if hasValidServiceIP(se.Service) && hasValidEndpointIP(se.Endpoint) {
 			svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
 			oldPodIP := se.Endpoint.Subsets[0].Addresses[0].IP
-			if err := c.Proxy.DeletePortFilter(svcIP, oldPodIP); err != nil {
-				log.Error(err, "failed to delete port filter on endpoint invalidation", "svcIP", svcIP, "podIP", oldPodIP)
-			}
+			c.clearPortFilter(svcIP, oldPodIP, "on endpoint invalidation")
 			c.Proxy.DeleteRules(svcIP, oldPodIP)
 		}
 		c.Services.SetEndpoint(ep.Namespace, ep.Name, ep)
@@ -459,15 +423,7 @@ func (c *ServicesController) updateEndpointFunc(oldObj, newObj interface{}) {
 	svcIP := se.Service.Status.LoadBalancer.Ingress[0].IP
 	podIP := ep.Subsets[0].Addresses[0].IP
 	c.Proxy.EnsureRules(svcIP, podIP)
-	if wholeIPPassthrough(se.Service) {
-		if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
-			log.Error(err, "failed to delete port filter on endpoint update", "svcIP", svcIP, "podIP", podIP)
-		}
-	} else {
-		if err := c.Proxy.EnsurePortFilter(svcIP, podIP, se.Service.Spec.Ports); err != nil {
-			log.Error(err, "failed to ensure port filter on endpoint update", "svcIP", svcIP, "podIP", podIP)
-		}
-	}
+	c.reconcilePortFilter(se.Service, svcIP, podIP, "on endpoint update")
 	c.Services.SetEndpoint(ep.Namespace, ep.Name, ep)
 }
 
@@ -506,7 +462,10 @@ func hasValidEndpointIP(ep *v1.Endpoints) bool {
 	return ep.Subsets[0].Addresses[0].IP != ""
 }
 
-const wholeIPAnnotation = "networking.cozystack.io/wholeIP"
+const (
+	wholeIPAnnotation   = "networking.cozystack.io/wholeIP"
+	allowICMPAnnotation = "networking.cozystack.io/allowICMP"
+)
 
 // hasWholeIPAnnotation reports whether the service is opted into cozy-proxy
 // management via the wholeIP annotation. Any value triggers management — the
@@ -528,6 +487,54 @@ func wholeIPPassthrough(svc *v1.Service) bool {
 		return true
 	}
 	return svc.Annotations[wholeIPAnnotation] != "false"
+}
+
+// allowICMP reports whether ICMP traffic should bypass the port_filter drop
+// rule for this service. Only meaningful in port-filter mode (wholeIP=false);
+// in passthrough mode the port_filter drop rule does not apply at all.
+func allowICMP(svc *v1.Service) bool {
+	if svc == nil || svc.Annotations == nil {
+		return false
+	}
+	return svc.Annotations[allowICMPAnnotation] == "true"
+}
+
+// reconcilePortFilter applies the port-filter and ICMP-allow state implied by
+// the service's annotations. Call sites pass the resolved svcIP/podIP and a
+// short context string that ends up in error logs.
+func (c *ServicesController) reconcilePortFilter(svc *v1.Service, svcIP, podIP, ctx string) {
+	if wholeIPPassthrough(svc) {
+		if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
+			log.Error(err, "failed to delete port filter "+ctx, "svcIP", svcIP, "podIP", podIP)
+		}
+		if err := c.Proxy.DeleteICMPAllow(svcIP, podIP); err != nil {
+			log.Error(err, "failed to delete ICMP allow "+ctx, "svcIP", svcIP, "podIP", podIP)
+		}
+		return
+	}
+	if err := c.Proxy.EnsurePortFilter(svcIP, podIP, svc.Spec.Ports); err != nil {
+		log.Error(err, "failed to ensure port filter "+ctx, "svcIP", svcIP, "podIP", podIP)
+	}
+	if allowICMP(svc) {
+		if err := c.Proxy.EnsureICMPAllow(svcIP, podIP); err != nil {
+			log.Error(err, "failed to ensure ICMP allow "+ctx, "svcIP", svcIP, "podIP", podIP)
+		}
+	} else {
+		if err := c.Proxy.DeleteICMPAllow(svcIP, podIP); err != nil {
+			log.Error(err, "failed to delete ICMP allow "+ctx, "svcIP", svcIP, "podIP", podIP)
+		}
+	}
+}
+
+// clearPortFilter unconditionally removes both port-filter and ICMP-allow
+// state for (svcIP, podIP). Used by delete paths.
+func (c *ServicesController) clearPortFilter(svcIP, podIP, ctx string) {
+	if err := c.Proxy.DeletePortFilter(svcIP, podIP); err != nil {
+		log.Error(err, "failed to delete port filter "+ctx, "svcIP", svcIP, "podIP", podIP)
+	}
+	if err := c.Proxy.DeleteICMPAllow(svcIP, podIP); err != nil {
+		log.Error(err, "failed to delete ICMP allow "+ctx, "svcIP", svcIP, "podIP", podIP)
+	}
 }
 
 // cleanupRemovedServices performs an initial cleanup for removed services.
@@ -576,6 +583,24 @@ func (c *ServicesController) cleanupRemovedServices() error {
 	}
 	if err := c.Proxy.CleanupPortFilters(keepFilters); err != nil {
 		return fmt.Errorf("failed to perform port-filter cleanup: %w", err)
+	}
+	// Build ICMP-allow snapshot: services in port-filter mode that opt into
+	// ICMP via the allowICMP annotation.
+	keepICMP := make(map[string]string)
+	for _, se := range allServices {
+		if se.Service == nil || se.Endpoint == nil {
+			continue
+		}
+		if !hasValidServiceIP(se.Service) || !hasValidEndpointIP(se.Endpoint) {
+			continue
+		}
+		if wholeIPPassthrough(se.Service) || !allowICMP(se.Service) {
+			continue
+		}
+		keepICMP[se.Service.Status.LoadBalancer.Ingress[0].IP] = se.Endpoint.Subsets[0].Addresses[0].IP
+	}
+	if err := c.Proxy.CleanupICMPAllow(keepICMP); err != nil {
+		return fmt.Errorf("failed to perform ICMP-allow cleanup: %w", err)
 	}
 	return nil
 }

--- a/pkg/controllers/services_controller_test.go
+++ b/pkg/controllers/services_controller_test.go
@@ -51,3 +51,25 @@ func TestWholeIPPassthrough(t *testing.T) {
 		})
 	}
 }
+
+func TestAllowICMP(t *testing.T) {
+	cases := []struct {
+		name   string
+		svc    *v1.Service
+		expect bool
+	}{
+		{"explicit true", svcWith(map[string]string{"networking.cozystack.io/allowICMP": "true"}), true},
+		{"explicit false", svcWith(map[string]string{"networking.cozystack.io/allowICMP": "false"}), false},
+		{"empty value", svcWith(map[string]string{"networking.cozystack.io/allowICMP": ""}), false},
+		{"absent annotation defaults to false", svcWith(map[string]string{}), false},
+		{"nil annotations defaults to false", &v1.Service{}, false},
+		{"unrelated annotation", svcWith(map[string]string{"networking.cozystack.io/wholeIP": "false"}), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := allowICMP(c.svc); got != c.expect {
+				t.Errorf("allowICMP = %v, want %v", got, c.expect)
+			}
+		})
+	}
+}

--- a/pkg/proxy/dummy.go
+++ b/pkg/proxy/dummy.go
@@ -43,5 +43,20 @@ func (d *DummyProxyProcessor) CleanupPortFilters(keep map[string]PortFilterEntry
 	return nil
 }
 
+func (d *DummyProxyProcessor) EnsureICMPAllow(SvcIP, PodIP string) error {
+	fmt.Printf("EnsureICMPAllow called with SvcIP: %s, PodIP: %s\n", SvcIP, PodIP)
+	return nil
+}
+
+func (d *DummyProxyProcessor) DeleteICMPAllow(SvcIP, PodIP string) error {
+	fmt.Printf("DeleteICMPAllow called with SvcIP: %s, PodIP: %s\n", SvcIP, PodIP)
+	return nil
+}
+
+func (d *DummyProxyProcessor) CleanupICMPAllow(keep map[string]string) error {
+	fmt.Printf("CleanupICMPAllow called with %d entries\n", len(keep))
+	return nil
+}
+
 // Compile-time assertion that DummyProxyProcessor satisfies ProxyProcessor.
 var _ ProxyProcessor = (*DummyProxyProcessor)(nil)

--- a/pkg/proxy/interface.go
+++ b/pkg/proxy/interface.go
@@ -24,6 +24,20 @@ type ProxyProcessor interface {
 	// keepFilters. Any stale entries are removed. The PortFilterEntry struct
 	// carries both the pod IP (used as the actual nft key) and the ports.
 	CleanupPortFilters(keepFilters map[string]PortFilterEntry) error
+
+	// EnsureICMPAllow adds the pod IP to the ICMP allowlist consulted by the
+	// port_filter chain. With this in place, ICMP traffic to a pod that is
+	// otherwise port-filtered is accepted instead of dropped (preserves ping,
+	// PMTU discovery, ICMP unreachable signalling). Idempotent.
+	EnsureICMPAllow(SvcIP, PodIP string) error
+
+	// DeleteICMPAllow removes the pod IP from the ICMP allowlist. No-op if
+	// not present.
+	DeleteICMPAllow(SvcIP, PodIP string) error
+
+	// CleanupICMPAllow keeps only the entries listed in keepICMP (svcIP →
+	// podIP) in the ICMP allowlist; everything else is removed.
+	CleanupICMPAllow(keepICMP map[string]string) error
 }
 
 // PortFilterEntry describes a port-filter desired state in the controller's

--- a/pkg/proxy/nft.go
+++ b/pkg/proxy/nft.go
@@ -28,9 +28,10 @@ type NFTProxyProcessor struct {
 	svcPodMap *nftables.Set // Map "svc_pod": maps svc IP → pod IP.
 
 	// Port-filtering objects (post-DNAT, key on pod IP).
-	filteredPods *nftables.Set   // set of pod IPs subject to port filtering.
-	allowedPorts *nftables.Set   // concat set: (ipv4_addr . inet_proto . inet_service).
-	portFilterCh *nftables.Chain // chain "port_filter" running post-conntrack and post-ingress_dnat.
+	filteredPods    *nftables.Set   // set of pod IPs subject to port filtering.
+	allowedPorts    *nftables.Set   // concat set: (ipv4_addr . inet_proto . inet_service).
+	icmpAllowedPods *nftables.Set   // set of pod IPs that should accept ICMP in port_filter.
+	portFilterCh    *nftables.Chain // chain "port_filter" running post-conntrack and post-ingress_dnat.
 }
 
 // InitRules initializes the nftables configuration in a single table "cozy_proxy".
@@ -124,6 +125,20 @@ func (p *NFTProxyProcessor) InitRules() error {
 		return fmt.Errorf("could not add allowed_ports set: %v", err)
 	}
 	log.Info("Created allowed_ports concat set", "set", p.allowedPorts.Name)
+
+	// Set "icmp_allowed_pods": pod IPs whose ICMP traffic should bypass the
+	// port_filter drop rule. Opt-in via the allowICMP service annotation,
+	// applies only to pods also present in filtered_pods.
+	p.icmpAllowedPods = &nftables.Set{
+		Table:   p.table,
+		Name:    "icmp_allowed_pods",
+		KeyType: nftables.TypeIPAddr,
+	}
+	if err := p.conn.AddSet(p.icmpAllowedPods, nil); err != nil {
+		log.Error(err, "Could not add icmp_allowed_pods set")
+		return fmt.Errorf("could not add icmp_allowed_pods set: %v", err)
+	}
+	log.Info("Created icmp_allowed_pods set", "set", p.icmpAllowedPods.Name)
 
 	// --- Delete Chains ---
 	chains, _ := p.conn.ListChains()
@@ -264,6 +279,47 @@ func (p *NFTProxyProcessor) InitRules() error {
 		},
 	})
 	log.Info("Added port_filter ct established,related accept rule")
+
+	// --- port_filter rule: ICMP opt-in accept ---
+	// Equivalent to:
+	//   ip daddr @icmp_allowed_pods meta l4proto icmp accept
+	//
+	// Without this, ICMP to a filtered pod IP is dropped by the rule below
+	// because it composes its lookup key from (daddr, l4proto, th_dport) and
+	// the controller only populates allowed_ports with TCP/UDP entries —
+	// breaking ping, PMTU discovery (ICMP Frag Needed), and ICMP unreachable
+	// signalling. Services that opt in via the allowICMP annotation get their
+	// pod IP added to icmp_allowed_pods, which gates this accept.
+	p.conn.AddRule(&nftables.Rule{
+		Table: p.table,
+		Chain: p.portFilterCh,
+		Exprs: []expr.Any{
+			// Gate: ip daddr in icmp_allowed_pods (continue if matched).
+			&expr.Payload{
+				DestRegister: 1,
+				Base:         expr.PayloadBaseNetworkHeader,
+				Offset:       16, // IPv4 daddr (post-ingress_dnat: pod IP)
+				Len:          4,
+			},
+			&expr.Lookup{
+				SourceRegister: 1,
+				SetName:        p.icmpAllowedPods.Name,
+				SetID:          p.icmpAllowedPods.ID,
+			},
+			// meta l4proto == ICMP.
+			&expr.Meta{
+				Key:      expr.MetaKeyL4PROTO,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     []byte{unix.IPPROTO_ICMP},
+			},
+			&expr.Verdict{Kind: expr.VerdictAccept},
+		},
+	})
+	log.Info("Added port_filter ICMP accept rule")
 
 	// --- port_filter rule ---
 	// Equivalent to:
@@ -802,6 +858,108 @@ func (p *NFTProxyProcessor) removeAllowedPortsForPod(parsedPodIP net.IP) error {
 			return fmt.Errorf("failed to delete stale allowed_ports for pod: %v", err)
 		}
 	}
+	return nil
+}
+
+// EnsureICMPAllow adds podIP to the icmp_allowed_pods set so that ICMP
+// traffic to that pod IP bypasses the port_filter drop rule. svcIP is used
+// only for logging context. Idempotent.
+func (p *NFTProxyProcessor) EnsureICMPAllow(svcIP, podIP string) error {
+	log.Info("Ensuring ICMP allow", "svcIP", svcIP, "podIP", podIP)
+	parsedPodIP := net.ParseIP(podIP).To4()
+	if parsedPodIP == nil {
+		return fmt.Errorf("invalid podIP: %s", podIP)
+	}
+	if err := p.conn.SetAddElements(p.icmpAllowedPods, []nftables.SetElement{{Key: parsedPodIP}}); err != nil {
+		return fmt.Errorf("failed to add %s to icmp_allowed_pods: %v", podIP, err)
+	}
+	if err := p.conn.Flush(); err != nil {
+		return fmt.Errorf("failed to flush EnsureICMPAllow: %v", err)
+	}
+	log.Info("ICMP allow ensured", "svcIP", svcIP, "podIP", podIP)
+	return nil
+}
+
+// DeleteICMPAllow removes podIP from icmp_allowed_pods. Tolerates ENOENT for
+// clean idempotency. svcIP is used only for logging context.
+func (p *NFTProxyProcessor) DeleteICMPAllow(svcIP, podIP string) error {
+	log.Info("Deleting ICMP allow", "svcIP", svcIP, "podIP", podIP)
+	parsedPodIP := net.ParseIP(podIP).To4()
+	if parsedPodIP == nil {
+		return fmt.Errorf("invalid podIP: %s", podIP)
+	}
+	if err := p.conn.SetDeleteElements(p.icmpAllowedPods, []nftables.SetElement{{Key: parsedPodIP}}); err != nil {
+		if !errors.Is(err, unix.ENOENT) {
+			return fmt.Errorf("failed to delete %s from icmp_allowed_pods: %v", podIP, err)
+		}
+	}
+	if err := p.conn.Flush(); err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			log.Info("DeleteICMPAllow ENOENT on flush — already gone", "podIP", podIP)
+			return nil
+		}
+		return fmt.Errorf("failed to flush DeleteICMPAllow: %v", err)
+	}
+	log.Info("ICMP allow deleted", "svcIP", svcIP, "podIP", podIP)
+	return nil
+}
+
+// CleanupICMPAllow reconciles icmp_allowed_pods with the desired snapshot.
+// keep is keyed by svcIP (caller convenience); the value is the podIP that
+// must remain in the set. Single-pass diff with one Flush, mirroring
+// CleanupPortFilters.
+func (p *NFTProxyProcessor) CleanupICMPAllow(keep map[string]string) error {
+	log.Info("Starting CleanupICMPAllow", "keepCount", len(keep))
+
+	desired := make(map[string]bool, len(keep))
+	for _, podIP := range keep {
+		if net.ParseIP(podIP).To4() == nil {
+			log.Info("Skipping invalid podIP in ICMP cleanup keep map", "podIP", podIP)
+			continue
+		}
+		desired[podIP] = true
+	}
+
+	current, err := p.conn.GetSetElements(p.icmpAllowedPods)
+	if err != nil {
+		return fmt.Errorf("failed to list icmp_allowed_pods: %v", err)
+	}
+
+	var addPods, delPods []nftables.SetElement
+	seen := make(map[string]bool, len(current))
+	for _, el := range current {
+		ipStr := net.IP(el.Key).String()
+		seen[ipStr] = true
+		if !desired[ipStr] {
+			delPods = append(delPods, nftables.SetElement{Key: el.Key})
+		}
+	}
+	for podIPStr := range desired {
+		if !seen[podIPStr] {
+			parsed := net.ParseIP(podIPStr).To4()
+			if parsed == nil {
+				continue
+			}
+			addPods = append(addPods, nftables.SetElement{Key: parsed})
+		}
+	}
+
+	if len(delPods) > 0 {
+		if err := p.conn.SetDeleteElements(p.icmpAllowedPods, delPods); err != nil {
+			return fmt.Errorf("failed to delete stale icmp_allowed_pods: %v", err)
+		}
+	}
+	if len(addPods) > 0 {
+		if err := p.conn.SetAddElements(p.icmpAllowedPods, addPods); err != nil {
+			return fmt.Errorf("failed to add icmp_allowed_pods: %v", err)
+		}
+	}
+
+	if err := p.conn.Flush(); err != nil {
+		return fmt.Errorf("failed to flush CleanupICMPAllow: %v", err)
+	}
+	log.Info("CleanupICMPAllow completed",
+		"addedPods", len(addPods), "removedPods", len(delPods))
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #11. In port-filter mode the previous PR drops all ICMP toward the backend pod IP, which breaks `ping`, PMTU discovery (ICMP "fragmentation needed"), and ICMP unreachable signalling. This adds an opt-in annotation to accept ICMP for services that need it.

- New annotation `networking.cozystack.io/allowICMP: "true"` (default false). Only meaningful in port-filter mode (`wholeIP: "false"`).
- New nft set `icmp_allowed_pods` and a rule in `port_filter` placed between the `ct established,related accept` and the per-port drop: `ip daddr @icmp_allowed_pods meta l4proto icmp accept`.
- New `ProxyProcessor` methods `EnsureICMPAllow` / `DeleteICMPAllow` / `CleanupICMPAllow`, mirroring the port-filter API shape.
- Controller wiring consolidated into `reconcilePortFilter` / `clearPortFilter` helpers — fewer scattered if/else blocks for both port-filter and ICMP state.
- Unit test for the new `allowICMP` predicate.
- README documents the annotation and updates the Datapath section.

## Why per-pod set, not per-rule

Same reason as `filtered_pods`/`allowed_ports`: the chain runs at priority `filter` (0), after `ingress_dnat` has rewritten daddr from LB IP to pod IP. Keying on pod IP keeps the chain rule count constant and the per-service state in nft sets, which is consistent with the rest of the design.

## Test plan

- [ ] `wholeIP: "false"` + `allowICMP: "true"`: ping VM works, port filter still in effect for TCP/UDP
- [ ] `wholeIP: "false"` without `allowICMP`: ICMP dropped (default)
- [ ] `wholeIP: "true"`: passthrough, ICMP works
- [ ] Toggle `allowICMP` true→false: pod removed from `icmp_allowed_pods`
- [ ] Service deletion cleans up `icmp_allowed_pods` entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `networking.cozystack.io/allowICMP` service annotation to selectively allow ICMP traffic to managed pods in port-filter mode.

* **Documentation**
  * Updated documentation explaining default ICMP drop behavior in port-filter mode and how the new annotation enables ICMP acceptance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->