### PR TITLE
feat: label-only selector and port-filter default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,37 +17,29 @@ The last option is the simplest and most flexible, but it has a limitation: Kube
 but only traffic on specific ports (see: [Kubernetes Issue #23864](https://github.com/kubernetes/kubernetes/issues/23864)).
 Additionally, kube-proxy does not perform SNAT, which causes outgoing traffic from the pod to use the default gateway of the host where it is running.
 
-To address these issues, we have added an additional controller that performs 1:1 NAT for services selected by either the `service.kubernetes.io/service-proxy-name: cozy-proxy` label or the `networking.cozystack.io/wholeIP` annotation.
+To address these issues, we have added an additional controller that performs NAT for services carrying the `service.kubernetes.io/service-proxy-name: cozy-proxy` label.
 
 ## How It Works
 
-cozy-proxy is a simple Kubernetes controller that watches for services selected by either of the following:
-
-- **`service.kubernetes.io/service-proxy-name: cozy-proxy`** label (recommended) — the standard Kubernetes mechanism for delegating a service to a non-default proxy. kube-proxy skips services carrying this label, so cozy-proxy becomes the sole handler and no rules collide.
-- **`networking.cozystack.io/wholeIP`** annotation — also selects the service for management. The annotation value additionally drives the ingress mode (see below).
+cozy-proxy is a simple Kubernetes controller that watches for services labeled with `service.kubernetes.io/service-proxy-name: cozy-proxy` — the standard Kubernetes mechanism for delegating a service to a non-default proxy. kube-proxy skips services carrying this label, so cozy-proxy becomes the sole handler and no rules collide.
 
 When it finds such a service, it creates NFT rules that forward traffic from the service's external IP to the pod's IP and vice versa, performing source-IP preservation for egress traffic.
 
 This controller can be used together with kube-proxy and Cilium in kube-proxy replacement mode.
 
-### Which selector should I use?
-
-- If your cluster runs **plain kube-proxy** (iptables or IPVS mode) — for example, a default RKE2/kubeadm install with Calico or Flannel — use the `service.kubernetes.io/service-proxy-name: cozy-proxy` label. Without it, kube-proxy installs its own LoadBalancer rules that conflict with cozy-proxy's NAT and break outbound SNAT.
-- If your cluster runs **Cilium in kube-proxy replacement mode** (as in the reference Cozystack environment), either selector works.
-
-You can safely set both on the same service.
+> The label is the **only** selector. Services that do not carry it are not managed by cozy-proxy, regardless of any annotations they may have.
 
 ## Ingress mode
 
-The `networking.cozystack.io/wholeIP` annotation value selects the ingress mode:
+The optional `networking.cozystack.io/wholeIP` annotation selects the ingress mode for a managed service:
 
-| Value     | Behavior                                                                                                        |
-|-----------|-----------------------------------------------------------------------------------------------------------------|
-| `"true"`  | **Whole-IP passthrough.** All TCP/UDP traffic to the LoadBalancer IP is forwarded to the backend pod.           |
-| `"false"` | **Per-port filtering.** Only TCP/UDP traffic to ports listed in `Service.spec.ports` is forwarded; rest dropped.|
-| absent    | Defaults to **passthrough** (services selected by label only behave the same as `wholeIP: "true"`).             |
+| Value     | Behavior                                                                                                              |
+|-----------|-----------------------------------------------------------------------------------------------------------------------|
+| `"true"`  | **Whole-IP passthrough.** All TCP/UDP traffic to the LoadBalancer IP is forwarded to the backend pod.                 |
+| `"false"` | **Per-port filtering** (default). Only TCP/UDP traffic to ports listed in `Service.spec.ports` is forwarded; rest dropped. |
+| absent    | Same as `"false"` — per-port filtering.                                                                               |
 
-In both managed modes, egress traffic from the backend pod is SNATed to the
+In both modes, egress traffic from the backend pod is SNATed to the
 LoadBalancer IP for source-IP preservation.
 
 The optional `networking.cozystack.io/allowICMP: "true"` annotation, only
@@ -88,7 +80,7 @@ helm install cozy-proxy charts/cozy-proxy -n kube-system
 
 ## Usage
 
-Create a LoadBalancer service with the `service.kubernetes.io/service-proxy-name: cozy-proxy` label. This also tells kube-proxy to stay away from the service:
+Create a LoadBalancer service with the `service.kubernetes.io/service-proxy-name: cozy-proxy` label. The default mode is per-port filtering, so to forward every port to the backend pod (whole-IP passthrough) add the `networking.cozystack.io/wholeIP: "true"` annotation:
 
 ```yaml
 apiVersion: v1
@@ -97,6 +89,8 @@ metadata:
   name: example-service
   labels:
     service.kubernetes.io/service-proxy-name: cozy-proxy
+  annotations:
+    networking.cozystack.io/wholeIP: "true"
 spec:
   allocateLoadBalancerNodePorts: false
   externalTrafficPolicy: Local

--- a/pkg/controllers/services_controller.go
+++ b/pkg/controllers/services_controller.go
@@ -475,42 +475,27 @@ const (
 	serviceProxyName = "cozy-proxy"
 )
 
-// isCozyProxyService reports whether the service should be managed by cozy-proxy.
-// A service is selected if it carries the
-// service.kubernetes.io/service-proxy-name=cozy-proxy label (standard
-// Kubernetes mechanism, also tells kube-proxy to ignore the service) or the
-// networking.cozystack.io/wholeIP annotation (any value — the value drives
-// passthrough vs port-filter mode, see wholeIPPassthrough).
+// isCozyProxyService reports whether the service should be managed by
+// cozy-proxy. The sole selector is the standard Kubernetes
+// service.kubernetes.io/service-proxy-name=cozy-proxy label, which also
+// tells kube-proxy to ignore the service. Services without the label are
+// not managed regardless of any cozy-proxy annotations they may carry.
 func isCozyProxyService(svc *v1.Service) bool {
 	if svc == nil {
 		return false
 	}
-	if svc.Labels[serviceProxyNameLabel] == serviceProxyName {
-		return true
-	}
-	return hasWholeIPAnnotation(svc)
-}
-
-// hasWholeIPAnnotation reports whether the service carries the wholeIP
-// annotation. Any value is accepted; the value's meaning (passthrough vs
-// port-filter) is determined by wholeIPPassthrough.
-func hasWholeIPAnnotation(svc *v1.Service) bool {
-	if svc == nil {
-		return false
-	}
-	_, ok := svc.Annotations[wholeIPAnnotation]
-	return ok
+	return svc.Labels[serviceProxyNameLabel] == serviceProxyName
 }
 
 // wholeIPPassthrough reports whether ingress traffic should bypass port
-// filtering. Defaults to true for any value other than the explicit string
-// "false", so services selected by label alone (no annotation) and services
-// with annotation: "true" both behave as passthrough.
+// filtering. Opt-in: requires an explicit networking.cozystack.io/wholeIP=true
+// annotation. Any other value, or no annotation at all, keeps the service in
+// the default port-filter mode.
 func wholeIPPassthrough(svc *v1.Service) bool {
 	if svc == nil || svc.Annotations == nil {
-		return true
+		return false
 	}
-	return svc.Annotations[wholeIPAnnotation] != "false"
+	return svc.Annotations[wholeIPAnnotation] == "true"
 }
 
 // allowICMP reports whether ICMP traffic should bypass the port_filter drop

--- a/pkg/controllers/services_controller_test.go
+++ b/pkg/controllers/services_controller_test.go
@@ -11,22 +11,26 @@ func svcWith(annot map[string]string) *v1.Service {
 	return &v1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: annot}}
 }
 
-func TestHasWholeIPAnnotation(t *testing.T) {
+func svcWithLabels(labels map[string]string) *v1.Service {
+	return &v1.Service{ObjectMeta: metav1.ObjectMeta{Labels: labels}}
+}
+
+func TestIsCozyProxyService(t *testing.T) {
 	cases := []struct {
 		name   string
 		svc    *v1.Service
 		expect bool
 	}{
-		{"true value", svcWith(map[string]string{"networking.cozystack.io/wholeIP": "true"}), true},
-		{"false value", svcWith(map[string]string{"networking.cozystack.io/wholeIP": "false"}), true},
-		{"absent annotation", svcWith(map[string]string{}), false},
-		{"nil annotations", &v1.Service{}, false},
-		{"unrelated annotation", svcWith(map[string]string{"foo": "bar"}), false},
+		{"label with correct value", svcWithLabels(map[string]string{"service.kubernetes.io/service-proxy-name": "cozy-proxy"}), true},
+		{"label with other value", svcWithLabels(map[string]string{"service.kubernetes.io/service-proxy-name": "kube-router"}), false},
+		{"label absent", svcWithLabels(map[string]string{}), false},
+		{"nil service", nil, false},
+		{"only wholeIP annotation no label", svcWith(map[string]string{"networking.cozystack.io/wholeIP": "true"}), false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := hasWholeIPAnnotation(c.svc); got != c.expect {
-				t.Errorf("hasWholeIPAnnotation = %v, want %v", got, c.expect)
+			if got := isCozyProxyService(c.svc); got != c.expect {
+				t.Errorf("isCozyProxyService = %v, want %v", got, c.expect)
 			}
 		})
 	}
@@ -38,10 +42,11 @@ func TestWholeIPPassthrough(t *testing.T) {
 		svc    *v1.Service
 		expect bool
 	}{
-		{"true value", svcWith(map[string]string{"networking.cozystack.io/wholeIP": "true"}), true},
-		{"false value", svcWith(map[string]string{"networking.cozystack.io/wholeIP": "false"}), false},
-		{"absent annotation defaults to passthrough", svcWith(map[string]string{}), true},
-		{"nil annotations defaults to passthrough", &v1.Service{}, true},
+		{"explicit true", svcWith(map[string]string{"networking.cozystack.io/wholeIP": "true"}), true},
+		{"explicit false", svcWith(map[string]string{"networking.cozystack.io/wholeIP": "false"}), false},
+		{"empty value", svcWith(map[string]string{"networking.cozystack.io/wholeIP": ""}), false},
+		{"absent annotation defaults to port-filter", svcWith(map[string]string{}), false},
+		{"nil annotations defaults to port-filter", &v1.Service{}, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Tightens the management contract before the next release:

1. **Label is the sole selector.** Services without `service.kubernetes.io/service-proxy-name: cozy-proxy` are no longer managed, even if they carry `networking.cozystack.io/wholeIP`. The annotation alone has no selecting effect anymore.
2. **Port-filter is the default mode.** `wholeIPPassthrough` is now an explicit opt-in via `wholeIP: "true"`. Absent or any other value falls into per-port filtering, so a Service's declared `spec.ports` are the only ports cozy-proxy forwards by default.

Drops the now-unused `hasWholeIPAnnotation` helper. Tests cover the new selector and the new default. README rewritten — drops the dual-selector narrative, removes the "Which selector should I use?" section, marks port-filter as default, and updates the Usage example to include `wholeIP: "true"` so the bogus-port-65535 passthrough demonstration still makes sense.

## Breaking changes

- Services using the `wholeIP` annotation **without** the `service-proxy-name` label are no longer managed. Add the label.
- Services that relied on the absent-annotation default (passthrough) now fall back to port-filter. Add `networking.cozystack.io/wholeIP: "true"` to keep the previous behavior.

Both behaviors are recent (#9, #11), unreleased, so the breakage scope is limited to in-tree consumers.

## Test plan

- [x] Unit tests pass
- [ ] Service with label only, no annotation, declared spec.ports: [22]: only port 22 reachable
- [ ] Service with label + wholeIP: "true": all ports reachable
- [ ] Service with wholeIP annotation only, no label: not managed (no rules created)
- [ ] Service with label + wholeIP: "false" + allowICMP: "true": ports 22 + ICMP work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated service selection and configuration guidance.

* **Changes**
  * Service selection now relies on a single label instead of multiple selectors.
  * Default behavior changed to per-port filtering; whole-IP passthrough now requires explicit configuration.
  * Updated configuration examples to reflect new requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->